### PR TITLE
Updates for bulding on macos

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,12 +1,13 @@
 version: '2'
 
 services:
+
   basket.api:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ConnectionString=basket.data
       #- identityUrl=http://13.88.8.119:5105             #Remote: VM Needs to have public access at 5105. 
-      - identityUrl=http://10.0.75.1:5105              #Local: You need to open your local dev-machine firewall at range 5100-5105.  at range 5100-5105. 
+      - identityUrl=http://identity.api:5105              #Local: You need to open your local dev-machine firewall at range 5100-5105.  at range 5100-5105. 
     ports:
       - "5103:5103"
 
@@ -15,10 +16,9 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ConnectionString=Server=sql.data;Database=Microsoft.eShopOnContainers.Services.CatalogDb;User Id=sa;Password=Pass@word
       #- ExternalCatalogBaseUrl=http://13.88.8.119:5101   #Remote: VM Needs to have public access at 5105. 
-      - ExternalCatalogBaseUrl=http://10.0.75.1:5101    #Local: You need to open your local dev-machine firewall at range 5100-5105.  at range 5100-5105.
+      - ExternalCatalogBaseUrl=http://localhost:5101    #Local: You need to open your local dev-machine firewall at range 5100-5105.  at range 5100-5105.
     ports:
       - "5101:5101"
-
 
   identity.api:
     environment:
@@ -26,7 +26,7 @@ services:
       - SpaClient=http://localhost:5104
       - ConnectionStrings__DefaultConnection=Server=sql.data;Database=Microsoft.eShopOnContainers.Service.IdentityDb;User Id=sa;Password=Pass@word
       #- MvcClient=http://13.88.8.119:5100              #Remote: VM Needs to have public access at 5105. 
-      - MvcClient=http://10.0.75.1:5105              #Local: You need to open your local dev-machine firewall at range 5100-5105.  
+      - MvcClient=http://localhost:5100              #Local: You need to open your local dev-machine firewall at range 5100-5105.  
     ports:
       - "5105:5105"
 
@@ -35,18 +35,18 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ConnectionString=Server=sql.data;Database=Microsoft.eShopOnContainers.Services.OrderingDb;User Id=sa;Password=Pass@word
       #- identityUrl=http://13.88.8.119:5105             #Remote: VM Needs to have public access at 5105. 
-      - identityUrl=http://10.0.75.1:5105              #Local: You need to open your local dev-machine firewall at range 5100-5105.  at range 5100-5105. 
+      - identityUrl=http://identity.api:5105              #Local: You need to open your local dev-machine firewall at range 5100-5105.  at range 5100-5105. 
     ports:
       - "5102:5102"
 
-  eshoponcontainers.webspa:
+  webspa:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - CatalogUrl=http://10.0.75.1:5101
-      - OrderingUrl=http://10.0.75.1:5102
+      - CatalogUrl=http://localhost:5101
+      - OrderingUrl=http://localhost:5102
       #- IdentityUrl=http://13.88.8.119:5105             #Remote: VM Needs to have public access at 5105. 
-      - IdentityUrl=http://10.0.75.1:5105              #Local: You need to open your local dev-machine firewall at range 5100-5105.  at range 5100-5105. 
-      - BasketUrl=http://10.0.75.1:5103                
+      - IdentityUrl=http://localhost:5105              #Local: You need to open your local dev-machine firewall at range 5100-5105.  at range 5100-5105. 
+      - BasketUrl=http://localhost:5103                
     ports:
       - "5104:5104"
 
@@ -56,7 +56,7 @@ services:
       - CatalogUrl=http://catalog.api:5101
       - OrderingUrl=http://ordering.api:5102
       #- IdentityUrl=http://13.88.8.119:5105             #Remote: VM Needs to have public access at 5105. 
-      - IdentityUrl=http://10.0.75.1:5105              #Local: You need to open your local dev-machine firewall at range 5100-5105.  at range 5100-5105. 
+      - IdentityUrl=http://identity.api:5105              #Local: You need to open your local dev-machine firewall at range 5100-5105.  at range 5100-5105. 
       - BasketUrl=http://basket.api:5103
     ports:
       - "5100:5100"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,8 @@ services:
     depends_on:
       - sql.data
 
-  eshoponcontainers.webspa:
-    image: eshop/eshoponcontainers.webspa
+  webspa:
+    image: eshop/webspa
     build:
       context: ./src/Web/WebSPA/eShopOnContainers.WebSPA
       dockerfile: Dockerfile

--- a/src/Services/Basket/Basket.API/Basket.API.csproj
+++ b/src/Services/Basket/Basket.API/Basket.API.csproj
@@ -13,7 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Update="wwwroot;Views;Areas\**\Views;appsettings.json;web.config;Dockerfile;docker-compose.yml;.dockerignore">
+    <Content Update="web.config">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include=".dockerignore">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>

--- a/src/Services/Catalog/Catalog.API/Catalog.API.csproj
+++ b/src/Services/Catalog/Catalog.API/Catalog.API.csproj
@@ -13,11 +13,19 @@
     <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
 
+
   <ItemGroup>
-    <Content Update="wwwroot;Pics\**\*;Views;Areas\**\Views;settings.json;web.config;project.json;Dockerfile">
+    <Content Update="wwwroot;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include="Pics\**\*;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="web.config;">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.0" />

--- a/src/Services/Identity/Identity.API/Identity.API.csproj
+++ b/src/Services/Identity/Identity.API/Identity.API.csproj
@@ -14,7 +14,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Update="wwwroot\**\*;Views\**\*;Areas\**\Views;appsettings.json;web.config;Dockerfile;docker-compose.yml;.dockerignore">
+    <Content Update="wwwroot;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="Views\**\*;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="web.config;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include=".dockerignore">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>

--- a/src/Services/Ordering/Ordering.API/Ordering.API.csproj
+++ b/src/Services/Ordering/Ordering.API/Ordering.API.csproj
@@ -14,7 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Update="wwwroot;Views;Areas\**\Views;settings.json;web.config;docker-compose.yml;docker-compose.debug.yml;Dockerfile.debug;Dockerfile;.dockerignore">
+    <Content Update="web.config;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include=".dockerignore;">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>

--- a/src/Web/WebMVC/WebMVC.csproj
+++ b/src/Web/WebMVC/WebMVC.csproj
@@ -14,7 +14,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Update="wwwroot\**\*;Views\**\*;Areas\**\Views;appsettings.json;appsettings.override.json;web.config;Dockerfile;docker-compose.yml;.dockerignore">
+    <Content Update="wwwroot\**\*;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="Views\**\*;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="appsettings.json;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="web.config">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update=".dockerignore">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>

--- a/src/Web/WebSPA/eShopOnContainers.WebSPA/eShopOnContainers.WebSPA.csproj
+++ b/src/Web/WebSPA/eShopOnContainers.WebSPA/eShopOnContainers.WebSPA.csproj
@@ -17,7 +17,25 @@
 
   <ItemGroup>
     <Compile Remove="node_modules\**\*;Client\**\*" />
-    <Content Update="appsettings.json;Client\**\*;typings;Views\**\*;tsconfig.json;tsd.json;web.config;config\**\*;wwwroot\**\*;dockerfile">
+    <Content Update="appsettings.json;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="Client\**\*;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="Views\**\*;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="tsconfig.json;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="web.config;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="config\**\*;">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Update="wwwroot\**\*;">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
@@ -50,6 +68,7 @@
   </ItemGroup>
 
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
+    <Exec Command="npm install" />
     <Exec Command="npm run build:prod" />
   </Target>
 


### PR DESCRIPTION
There were a number of issues when following the readme to build and run the application on a Mac:

1. the build-images.sh script did not have execute privileges.
1. The build-images.sh script did not run dotnet restore in any of the projects.
1. The build-images.sh script did not build the Identity project, or the webSPA project.
1. The build-images.sh script did not run npm install or npm run build:prod for the SPA application. This has been fixed by adding the npm install step to the pre-publish script.
1. The csproj file built from `dotnet migrate` contains content nodes that won't publish correctly. See [CLI Issue #5753](https://github.com/dotnet/cli/issues/5753) for details.
1. the 10.0.75.1 IP is not setup by Docker on mac. Research indicates that within the container network, using the service name is preferred. (This should also work on Windows) That's going to require editing the hosts file again.

