### PR TITLE
Use DI instead of a service locator

### DIFF
--- a/src/Web/Catalog.WebForms/Catalog.WebForms/Catalog.WebForms.csproj
+++ b/src/Web/Catalog.WebForms/Catalog.WebForms/Catalog.WebForms.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Models\CatalogItem.cs" />
     <Compile Include="Models\CatalogRoot.cs" />
     <Compile Include="Models\CatalogType.cs" />
+    <Compile Include="Modules\AutoFacHttpModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\CatalogMockService.cs" />
     <Compile Include="Services\CatalogService.cs" />

--- a/src/Web/Catalog.WebForms/Catalog.WebForms/Default.aspx.cs
+++ b/src/Web/Catalog.WebForms/Catalog.WebForms/Default.aspx.cs
@@ -18,6 +18,13 @@ namespace Microsoft.eShopOnContainers.Catalog.WebForms
 
         private ICatalogService catalog;
 
+        protected _Default() { }
+
+        public _Default(ICatalogService catalog)
+        {
+            this.catalog = catalog;
+        }
+
         protected override void OnLoad(EventArgs e)
         {
             RegisterAsyncTask(new PageAsyncTask(LoadCatalogDataAsync));
@@ -27,14 +34,9 @@ namespace Microsoft.eShopOnContainers.Catalog.WebForms
 
         private async Task LoadCatalogDataAsync()
         {
-            var container = Application.Get("container") as IContainer;
-            using (scope = container?.BeginLifetimeScope())
-            {
-                catalog = container?.Resolve<ICatalogService>();
-                var collection = await catalog?.GetCatalogAsync();
-                catalogList.DataSource = collection;
-                catalogList.DataBind();
-            }
+            var collection = await catalog?.GetCatalogAsync();
+            catalogList.DataSource = collection;
+            catalogList.DataBind();
         }
 
         protected void Page_Load(object sender, EventArgs e)

--- a/src/Web/Catalog.WebForms/Catalog.WebForms/Global.asax.cs
+++ b/src/Web/Catalog.WebForms/Catalog.WebForms/Global.asax.cs
@@ -1,14 +1,7 @@
-﻿using Autofac;
-using eShopOnContainers.Core.Services.Catalog;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 using System.Web;
-using System.Web.Configuration;
 using System.Web.Optimization;
 using System.Web.Routing;
-using System.Web.Security;
-using System.Web.SessionState;
 
 namespace Microsoft.eShopOnContainers.Catalog.WebForms
 {
@@ -21,21 +14,6 @@ namespace Microsoft.eShopOnContainers.Catalog.WebForms
             RouteConfig.RegisterRoutes(RouteTable.Routes);
             BundleConfig.RegisterBundles(BundleTable.Bundles);
 
-            // Register Containers:
-            var settings= WebConfigurationManager.AppSettings;
-            var useFake = settings["usefake"];
-            bool fake = useFake == "true";
-            var builder = new ContainerBuilder();
-            if (fake)
-            {
-                builder.RegisterType<CatalogMockService>()
-                    .As<ICatalogService>();
-            } else {
-                builder.RegisterType<CatalogMockService>()
-                    .As<ICatalogService>();
-            }
-            var container = builder.Build();
-            Application.Add("container", container);
         }
     }
 }

--- a/src/Web/Catalog.WebForms/Catalog.WebForms/Modules/AutoFacHttpModule.cs
+++ b/src/Web/Catalog.WebForms/Catalog.WebForms/Modules/AutoFacHttpModule.cs
@@ -1,0 +1,84 @@
+﻿using Autofac;
+using eShopOnContainers.Core.Services.Catalog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Configuration;
+using System.Web.UI;
+
+namespace Microsoft.eShopOnContainers.Catalog.WebForms.Modules
+{
+    // Using DI with WebForms is not yet implemented.
+    // This implementation has been adapted from this post:
+    // https://blogs.msdn.microsoft.com/webdev/2016/10/19/modern-asp-net-web-forms-development-dependency-injection/
+
+    public class AutoFacHttpModule : IHttpModule
+    {
+        private static IContainer Container => lazyContainer.Value;
+
+        private static Lazy<IContainer> lazyContainer = new Lazy<IContainer>(() => CreateContainer());
+
+        private static IContainer CreateContainer()
+        {
+            // Configure AutoFac:
+            // Register Containers:
+            var settings = WebConfigurationManager.AppSettings;
+            var useFake = settings["usefake"];
+            bool fake = useFake == "true";
+            var builder = new ContainerBuilder();
+            if (fake)
+            {
+                builder.RegisterType<CatalogMockService>()
+                    .As<ICatalogService>();
+            }
+            else
+            {
+                builder.RegisterType<CatalogMockService>()
+                    .As<ICatalogService>();
+            }
+            var container = builder.Build();
+            return container;
+        }
+
+        public void Dispose()
+        {
+            Container.Dispose();
+        }
+
+        public void Init(HttpApplication context)
+        {
+            context.PreRequestHandlerExecute += (_, __) => InjectDependencies();
+        }
+
+        private void InjectDependencies()
+        {
+            if  (HttpContext.Current.CurrentHandler is Page)
+            {
+                var page = HttpContext.Current.CurrentHandler as Page;
+                // Get the code-behind class that we may have written
+                var pageType = page.GetType().BaseType;
+
+                // Determine if there is a constructor to inject, and grab it
+                var ctor = (from c in pageType.GetConstructors()
+                            where c.GetParameters().Length > 0
+                            select c).FirstOrDefault();
+
+                if (ctor != null)
+                {
+                    // Resolve the parameters for the constructor
+                    var args = (from parm in ctor.GetParameters()
+                                select Container.Resolve(parm.ParameterType))
+                                .ToArray();
+
+                    // Execute the constructor method with the arguments resolved 
+                    ctor.Invoke(page, args);
+                }
+
+                // Use the Autofac method to inject any properties that can be filled by Autofac
+                Container.InjectProperties(page);
+
+            }
+        }
+    }
+}

--- a/src/Web/Catalog.WebForms/Catalog.WebForms/Web.config
+++ b/src/Web/Catalog.WebForms/Catalog.WebForms/Web.config
@@ -20,6 +20,8 @@
     </pages>
     <httpModules>
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
+      <!--  Use this if you are on IIS 7 and earlier -->
+      <add name="InjectModule" type="Microsoft.eShopOnContainers.Catalog.WebForms.Modules.AutoFacHttpModule, Catalog.WebForms"/>
     </httpModules>
   </system.web>
   <runtime>
@@ -39,6 +41,8 @@
     <modules>
       <remove name="ApplicationInsightsWebTracking" />
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
+      <!-- Use this if you are on IIS 8 and later -->
+      <add name="InjectModule" type="Microsoft.eShopOnContainers.Catalog.WebForms.Modules.AutoFacHttpModule, Catalog.WebForms" />
     </modules>
   </system.webServer>
   <system.codedom>


### PR DESCRIPTION
Instead of creating a global service locator object, create an HTTP module that injects dependencies using AutoFac when the page is created.

Based on the solution written here: https://blogs.msdn.microsoft.com/webdev/2016/10/19/modern-asp-net-web-forms-development-dependency-injection/


