### PR TITLE
Removes Docker profile from launchSettings.json

### DIFF
--- a/src/Console/eShopConsole/Properties/launchSettings.json
+++ b/src/Console/eShopConsole/Properties/launchSettings.json
@@ -1,8 +1,4 @@
 {
   "profiles": {
-    "Docker": {
-      "executablePath": "%WINDIR%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
-      "commandLineArgs": "-ExecutionPolicy RemoteSigned .\\DockerTask.ps1 -Run -Environment $(Configuration) -Machine '$(DockerMachineName)'"
-    }
   }
 }

--- a/src/Services/Basket/Basket.API/Properties/launchSettings.json
+++ b/src/Services/Basket/Basket.API/Properties/launchSettings.json
@@ -23,10 +23,6 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
-    },
-    "Docker": {
-      "launchBrowser": true,
-      "launchUrl": "http://localhost:{ServicePort}/api/values"
     }
   }
 }

--- a/src/Services/Catalog/Catalog.API/Properties/launchSettings.json
+++ b/src/Services/Catalog/Catalog.API/Properties/launchSettings.json
@@ -22,10 +22,6 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
-    },
-    "Docker": {
-      "launchBrowser": true,
-      "launchUrl": "http://localhost:{ServicePort}/api/values"
     }
   }
 }

--- a/src/Services/Ordering/Ordering.API/Properties/launchSettings.json
+++ b/src/Services/Ordering/Ordering.API/Properties/launchSettings.json
@@ -23,12 +23,6 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
-    },
-    "Docker": {
-      "executablePath": "%WINDIR%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
-      "commandLineArgs": "-ExecutionPolicy RemoteSigned .\\DockerTask.ps1 -Run -Environment $(Configuration) -Machine '$(DockerMachineName)'",
-      "launchBrowser": true,
-      "launchUrl": "http://localhost:{ServicePort}/api/environmentInfo/machinename"
     }
   }
 }

--- a/src/Web/WebMVC/Properties/launchSettings.json
+++ b/src/Web/WebMVC/Properties/launchSettings.json
@@ -21,10 +21,6 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
-    },
-    "Docker": {
-      "launchBrowser": true,
-      "launchUrl": "http://localhost:{ServicePort}"
     }
   }
 }


### PR DESCRIPTION
The Docker profiles are out-of-date and no longer used by Docker tools. The change is to remove them to avoid issues with VS 2017 RTW.