### PR TITLE
Update Compiler package

### DIFF
--- a/src/Web/Catalog.WebForms/Catalog.WebForms/Catalog.WebForms.csproj
+++ b/src/Web/Catalog.WebForms/Catalog.WebForms/Catalog.WebForms.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.0.1\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.0.1\build\Microsoft.Net.Compilers.props')" />
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
-  <Import Project="..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -292,8 +292,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.0.1\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.0.1\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Web/Catalog.WebForms/Catalog.WebForms/Default.aspx.cs
+++ b/src/Web/Catalog.WebForms/Catalog.WebForms/Default.aspx.cs
@@ -14,8 +14,6 @@ namespace Microsoft.eShopOnContainers.Catalog.WebForms
 {
     public partial class _Default : Page
     {
-        private ILifetimeScope scope;
-
         private ICatalogService catalog;
 
         protected _Default() { }

--- a/src/Web/Catalog.WebForms/Catalog.WebForms/Modules/AutoFacHttpModule.cs
+++ b/src/Web/Catalog.WebForms/Catalog.WebForms/Modules/AutoFacHttpModule.cs
@@ -53,9 +53,8 @@ namespace Microsoft.eShopOnContainers.Catalog.WebForms.Modules
 
         private void InjectDependencies()
         {
-            if  (HttpContext.Current.CurrentHandler is Page)
+            if  (HttpContext.Current.CurrentHandler is Page page)
             {
-                var page = HttpContext.Current.CurrentHandler as Page;
                 // Get the code-behind class that we may have written
                 var pageType = page.GetType().BaseType;
 

--- a/src/Web/Catalog.WebForms/Catalog.WebForms/Web.config
+++ b/src/Web/Catalog.WebForms/Catalog.WebForms/Web.config
@@ -5,7 +5,7 @@
   -->
 <configuration>
   <appSettings>
-    <add key="usefake" value="true"/>
+    <add key="usefake" value="true" />
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.5.2" />
@@ -21,7 +21,7 @@
     <httpModules>
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
       <!--  Use this if you are on IIS 7 and earlier -->
-      <add name="InjectModule" type="Microsoft.eShopOnContainers.Catalog.WebForms.Modules.AutoFacHttpModule, Catalog.WebForms"/>
+      <add name="InjectModule" type="Microsoft.eShopOnContainers.Catalog.WebForms.Modules.AutoFacHttpModule, Catalog.WebForms" />
     </httpModules>
   </system.web>
   <runtime>

--- a/src/Web/Catalog.WebForms/Catalog.WebForms/packages.config
+++ b/src/Web/Catalog.WebForms/Catalog.WebForms/packages.config
@@ -20,7 +20,7 @@
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Web.Optimization.WebForms" version="1.1.3" targetFramework="net452" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.3" targetFramework="net452" />
-  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net452" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="2.0.1" targetFramework="net452" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Modernizr" version="2.6.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />


### PR DESCRIPTION
This is necessary for C# 7 feature support.
See the pattern match is statement in AutoFacHttpModule.

@CESARDELATORRE this same change (update Microsoft.Net.Compilers package to 2.0 would likely be necessary for the MVC, SPA, and WebAPI packages to support the new language features.  I can do that on the dev branch if you'd like.