### PR TITLE
use non generic repository interface

### DIFF
--- a/src/Services/Ordering/Ordering.API/Application/Commands/CreateOrderCommandHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Commands/CreateOrderCommandHandler.cs
@@ -24,12 +24,12 @@
     public class CreateOrderCommandHandler
         : IAsyncRequestHandler<CreateOrderCommand, bool>
     {
-        private readonly IBuyerRepository<Buyer> _buyerRepository;
-        private readonly IOrderRepository<Order> _orderRepository;
+        private readonly IBuyerRepository _buyerRepository;
+        private readonly IOrderRepository _orderRepository;
         private readonly IIdentityService _identityService;
 
         // Using DI to inject infrastructure persistence Repositories
-        public CreateOrderCommandHandler(IBuyerRepository<Buyer> buyerRepository, IOrderRepository<Order> orderRepository, IIdentityService identityService)
+        public CreateOrderCommandHandler(IBuyerRepository buyerRepository, IOrderRepository orderRepository, IIdentityService identityService)
         {
             _buyerRepository = buyerRepository ?? throw new ArgumentNullException(nameof(buyerRepository));
             _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));

--- a/src/Services/Ordering/Ordering.API/Infrastructure/AutofacModules/ApplicationModule.cs
+++ b/src/Services/Ordering/Ordering.API/Infrastructure/AutofacModules/ApplicationModule.cs
@@ -27,11 +27,11 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.API.Infrastructure.Autof
                 .InstancePerLifetimeScope();
 
             builder.RegisterType<BuyerRepository>()
-                .As<IBuyerRepository<Buyer>>()
+                .As<IBuyerRepository>()
                 .InstancePerLifetimeScope();
 
             builder.RegisterType<OrderRepository>()
-                .As<IOrderRepository<Order>>()
+                .As<IOrderRepository>()
                 .InstancePerLifetimeScope();
 
             builder.RegisterType<RequestManager>()

--- a/src/Services/Ordering/Ordering.Domain/AggregatesModel/BuyerAggregate/IBuyerRepository.cs
+++ b/src/Services/Ordering/Ordering.Domain/AggregatesModel/BuyerAggregate/IBuyerRepository.cs
@@ -6,7 +6,7 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.B
     //This is just the RepositoryContracts or Interface defined at the Domain Layer
     //as requisite for the Buyer Aggregate
 
-    public interface IBuyerRepository<T> : IRepository<T> where T : IAggregateRoot
+    public interface IBuyerRepository : IRepository<Buyer>
     {
         Buyer Add(Buyer buyer);
 

--- a/src/Services/Ordering/Ordering.Domain/AggregatesModel/OrderAggregate/IOrderRepository.cs
+++ b/src/Services/Ordering/Ordering.Domain/AggregatesModel/OrderAggregate/IOrderRepository.cs
@@ -5,7 +5,7 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.O
     //This is just the RepositoryContracts or Interface defined at the Domain Layer
     //as requisite for the Order Aggregate
 
-    public interface IOrderRepository<T> : IRepository<T> where T : IAggregateRoot
+    public interface IOrderRepository : IRepository<Order>
     {
         Order Add(Order order);
     }

--- a/src/Services/Ordering/Ordering.Infrastructure/Repositories/BuyerRepository.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/Repositories/BuyerRepository.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace Microsoft.eShopOnContainers.Services.Ordering.Infrastructure.Repositories
 {
     public class BuyerRepository
-        : IBuyerRepository<Buyer>
+        : IBuyerRepository
     {
         private readonly OrderingContext _context;
 

--- a/src/Services/Ordering/Ordering.Infrastructure/Repositories/OrderRepository.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/Repositories/OrderRepository.cs
@@ -5,7 +5,7 @@ using System;
 namespace Microsoft.eShopOnContainers.Services.Ordering.Infrastructure.Repositories
 {
     public class OrderRepository
-        : IOrderRepository<Order> 
+        : IOrderRepository
     {
         private readonly OrderingContext _context;
 

--- a/test/Services/UnitTest/Ordering/Application/NewOrderCommandHandlerTest.cs
+++ b/test/Services/UnitTest/Ordering/Application/NewOrderCommandHandlerTest.cs
@@ -15,15 +15,15 @@ namespace UnitTest.Ordering.Application
     using Xunit;
     public class NewOrderRequestHandlerTest
     {
-        private readonly Mock<IBuyerRepository<Buyer>> _buyerRepositoryMock;
-        private readonly Mock<IOrderRepository<Order>> _orderRepositoryMock;
+        private readonly Mock<IBuyerRepository> _buyerRepositoryMock;
+        private readonly Mock<IOrderRepository> _orderRepositoryMock;
         private readonly Mock<IIdentityService> _identityServiceMock;
 
         public NewOrderRequestHandlerTest()
         {
 
-            _buyerRepositoryMock = new Mock<IBuyerRepository<Buyer>>();
-            _orderRepositoryMock = new Mock<IOrderRepository<Order>>();
+            _buyerRepositoryMock = new Mock<IBuyerRepository>();
+            _orderRepositoryMock = new Mock<IOrderRepository>();
             _identityServiceMock = new Mock<IIdentityService>();
         }
 


### PR DESCRIPTION
`IOrderRepository` makes more sense than `IOrderRepository<Order>` since we don't need `IOrderRepository<Buyer>`.