### PR TITLE
Fix #61 Async suffix for namig convention.

### DIFF
--- a/src/Services/Basket/Basket.API/Controllers/BasketController.cs
+++ b/src/Services/Basket/Basket.API/Controllers/BasketController.cs
@@ -26,7 +26,7 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API.Controllers
         [HttpGet("{id}")]
         public async Task<IActionResult> Get(string id)
         {
-            var basket = await _repository.GetBasket(id);
+            var basket = await _repository.GetBasketAsync(id);
 
             return Ok(basket);
         }
@@ -35,7 +35,7 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API.Controllers
         [HttpPost]
         public async Task<IActionResult> Post([FromBody]CustomerBasket value)
         {
-            var basket = await _repository.UpdateBasket(value);
+            var basket = await _repository.UpdateBasketAsync(value);
 
             return Ok(basket);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API.Controllers
         [HttpDelete("{id}")]
         public void Delete(string id)
         {
-            _repository.DeleteBasket(id);
+            _repository.DeleteBasketAsync(id);
         }
     }
 }

--- a/src/Services/Basket/Basket.API/Model/IBasketRepository.cs
+++ b/src/Services/Basket/Basket.API/Model/IBasketRepository.cs
@@ -7,8 +7,8 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API.Model
 {
     public interface IBasketRepository
     {
-        Task<CustomerBasket> GetBasket(string customerId);
-        Task<CustomerBasket> UpdateBasket(CustomerBasket basket);
-        Task<bool> DeleteBasket(string id);
+        Task<CustomerBasket> GetBasketAsync(string customerId);
+        Task<CustomerBasket> UpdateBasketAsync(CustomerBasket basket);
+        Task<bool> DeleteBasketAsync(string id);
     }
 }

--- a/src/Services/Basket/Basket.API/Model/RedisBasketRepository.cs
+++ b/src/Services/Basket/Basket.API/Model/RedisBasketRepository.cs
@@ -25,13 +25,13 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API.Model
 
         }
 
-        public async Task<bool> DeleteBasket(string id)
+        public async Task<bool> DeleteBasketAsync(string id)
         {
             var database = await GetDatabase();
             return await database.KeyDeleteAsync(id.ToString());
         }
 
-        public async Task<CustomerBasket> GetBasket(string customerId)
+        public async Task<CustomerBasket> GetBasketAsync(string customerId)
         {
             var database = await GetDatabase();
 
@@ -44,7 +44,7 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API.Model
             return JsonConvert.DeserializeObject<CustomerBasket>(data);
         }
 
-        public async Task<CustomerBasket> UpdateBasket(CustomerBasket basket)
+        public async Task<CustomerBasket> UpdateBasketAsync(CustomerBasket basket)
         {
             var database = await GetDatabase();
 
@@ -56,7 +56,7 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API.Model
             }
 
             _logger.LogInformation("basket item persisted succesfully");
-            return await GetBasket(basket.BuyerId);
+            return await GetBasketAsync(basket.BuyerId);
         }
 
         private async Task<IDatabase> GetDatabase()

--- a/src/Services/Ordering/Ordering.Infrastructure/Repositories/BuyerRepository.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/Repositories/BuyerRepository.cs
@@ -29,6 +29,7 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Infrastructure.Repositor
         {
             if (buyer.IsTransient())
             {
+                //TODO: when migrating to ef core 1.1.1 change Add by AddAsync-. A bug in ef core 1.1.0 does not allow to do it https://github.com/aspnet/EntityFramework/issues/7298 
                 return _context.Buyers
                     .Add(buyer)
                     .Entity;

--- a/src/Services/Ordering/Ordering.Infrastructure/Repositories/OrderRepository.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/Repositories/OrderRepository.cs
@@ -24,6 +24,7 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Infrastructure.Repositor
 
         public Order Add(Order order)
         {
+            //TODO: when migrating to ef core 1.1.1 change Add by AddAsync-. A bug in ef core 1.1.0 does not allow to do it https://github.com/aspnet/EntityFramework/issues/7298 
             return _context.Orders.Add(order)
                 .Entity;
         }

--- a/test/Services/IntegrationTests/Services/Basket/RedisBasketRepositoryTests.cs
+++ b/test/Services/IntegrationTests/Services/Basket/RedisBasketRepositoryTests.cs
@@ -25,7 +25,7 @@ namespace IntegrationTests.Services.Basket
         {
             var redisBasketRepository = BuildBasketRepository();
 
-            var basket = await redisBasketRepository.UpdateBasket(new CustomerBasket("customerId")
+            var basket = await redisBasketRepository.UpdateBasketAsync(new CustomerBasket("customerId")
             {
                 BuyerId = "buyerId",
                 Items = BuildBasketItems()
@@ -40,15 +40,15 @@ namespace IntegrationTests.Services.Basket
         {
             var redisBasketRepository = BuildBasketRepository();
 
-            var basket = await redisBasketRepository.UpdateBasket(new CustomerBasket("customerId")
+            var basket = await redisBasketRepository.UpdateBasketAsync(new CustomerBasket("customerId")
             {
                 BuyerId = "buyerId",
                 Items = BuildBasketItems()
             });
 
-            var deleteResult = await redisBasketRepository.DeleteBasket("buyerId");
+            var deleteResult = await redisBasketRepository.DeleteBasketAsync("buyerId");
 
-            var result = await redisBasketRepository.GetBasket(basket.BuyerId);
+            var result = await redisBasketRepository.GetBasketAsync(basket.BuyerId);
 
             Assert.True(deleteResult);
             Assert.Null(result);

--- a/test/Services/UnitTest/Basket/Application/BasketWebApiTest.cs
+++ b/test/Services/UnitTest/Basket/Application/BasketWebApiTest.cs
@@ -24,7 +24,7 @@ namespace UnitTest.Basket.Application
             var fakeCustomerId = "1";
             var fakeCustomerBasket = GetCustomerBasketFake(fakeCustomerId);
 
-            _basketRepositoryMock.Setup(x => x.GetBasket(It.IsAny<string>()))
+            _basketRepositoryMock.Setup(x => x.GetBasketAsync(It.IsAny<string>()))
                 .Returns(Task.FromResult(fakeCustomerBasket));
 
             //Act
@@ -43,7 +43,7 @@ namespace UnitTest.Basket.Application
             var fakeCustomerId = "1";
             var fakeCustomerBasket = GetCustomerBasketFake(fakeCustomerId);
 
-            _basketRepositoryMock.Setup(x => x.UpdateBasket(It.IsAny<CustomerBasket>()))
+            _basketRepositoryMock.Setup(x => x.UpdateBasketAsync(It.IsAny<CustomerBasket>()))
                 .Returns(Task.FromResult(fakeCustomerBasket));
 
             //Act


### PR DESCRIPTION
Fix for #61 As requested in the issue simple change of names to fit the naming convention for TAP. 

Ordering repositories will be changed to async when we migrate to ef core 1.1.1