### PR TITLE
Resolved SPA incompatibilities with dependencies 

### DIFF
--- a/src/Web/WebSPA/package.json
+++ b/src/Web/WebSPA/package.json
@@ -86,7 +86,7 @@
     "html-loader": "0.4.4",
     "html-webpack-plugin": "2.24.1",
     "json-loader": "0.5.4",
-    "node-sass": "3.9.3",
+    "node-sass": "4.5.0",
     "parse5": "2.1.5",
     "rimraf": "2.5.4",
     "sass-lint": "1.10.2",


### PR DESCRIPTION
#72  Resolved SPA incompatibilities with dependencies when installing a newer node version.
The actual version of node-sass dependency was not compatible with newest node versions so that the node-sass lib version used has been updated