### PR TITLE
Set application discriminators, work around Redis client issue

### DIFF
--- a/src/Services/Identity/Identity.API/Startup.cs
+++ b/src/Services/Identity/Identity.API/Startup.cs
@@ -54,6 +54,11 @@ namespace eShopOnContainers.Identity
 
             services.Configure<AppSettings>(Configuration);
 
+            services.AddDataProtection(opts =>
+            {
+                opts.ApplicationDiscriminator = "eshop.identity";
+            });
+
             services.AddMvc();
 
             services.AddTransient<IEmailSender, AuthMessageSender>();

--- a/src/Web/WebMVC/Startup.cs
+++ b/src/Web/WebMVC/Startup.cs
@@ -42,6 +42,11 @@ namespace Microsoft.eShopOnContainers.WebMVC
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddDataProtection(opts =>
+            {
+                opts.ApplicationDiscriminator = "eshop.webmvc";
+            });
+
             services.AddMvc();
             services.Configure<AppSettings>(Configuration);
             

--- a/src/Web/WebSPA/Startup.cs
+++ b/src/Web/WebSPA/Startup.cs
@@ -41,6 +41,11 @@ namespace eShopConContainers.WebSPA
         {
             services.Configure<AppSettings>(Configuration);
 
+            services.AddDataProtection(opts =>
+            {
+                opts.ApplicationDiscriminator = "eshop.webspa";
+            });
+
             services.AddAntiforgery(options => options.HeaderName = "X-XSRF-TOKEN");
 
             services.AddMvc()


### PR DESCRIPTION
A couple small changes to resolve issues I found hosting the app in Kubernetes:
1. Setting application discriminators prevents an app trying to decrypt another's cookie
1. When `Basket.API` connects to Redis, don't call `Dns.GetHostAddressesAsync` if the connection string is an IP address. It may return `[::1, 127.0.0.1]` for `"127.0.0.1"`. Then `ips.First()` is `::1`, which the Redis client can't handle.