### PR TITLE
Features/#146 clean basket with integrate event

### DIFF
--- a/src/BuildingBlocks/EventBus/IntegrationEventLogEF/Utilities/ResilientTransaction.cs
+++ b/src/BuildingBlocks/EventBus/IntegrationEventLogEF/Utilities/ResilientTransaction.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Events;
+using Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF.Services;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF.Utilities
+{
+    public class ResilientTransaction
+    {
+        private DbContext _context;
+        private ResilientTransaction(DbContext context) =>
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+
+        public static ResilientTransaction New (DbContext context) =>
+            new ResilientTransaction(context);        
+
+        public async Task ExecuteAsync(Func<Task> action)
+        {
+            //Use of an EF Core resiliency strategy when using multiple DbContexts within an explicit BeginTransaction():
+            //See: https://docs.microsoft.com/en-us/ef/core/miscellaneous/connection-resiliency
+            var strategy = _context.Database.CreateExecutionStrategy();
+            await strategy.ExecuteAsync(async () =>
+            {
+                using (var transaction = _context.Database.BeginTransaction())
+                {
+                    await action();
+                    transaction.Commit();
+                }
+            });
+        }
+    }
+}

--- a/src/Services/Basket/Basket.API/IntegrationEvents/EventHandling/OrderStartedIntegrationEventHandler.cs
+++ b/src/Services/Basket/Basket.API/IntegrationEvents/EventHandling/OrderStartedIntegrationEventHandler.cs
@@ -1,0 +1,27 @@
+﻿using Basket.API.IntegrationEvents.Events;
+using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Abstractions;
+using Microsoft.eShopOnContainers.Services.Basket.API.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Basket.API.IntegrationEvents.EventHandling
+{
+    public class OrderStartedIntegrationEventHandler : IIntegrationEventHandler<OrderStartedIntegrationEvent>
+    {
+        private readonly IBasketRepository _repository;
+        public OrderStartedIntegrationEventHandler(IBasketRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task Handle(OrderStartedIntegrationEvent @event)
+        {
+            await _repository.DeleteBasketAsync(@event.UserId.ToString());
+        }
+    }
+}
+
+
+

--- a/src/Services/Basket/Basket.API/IntegrationEvents/Events/OrderStartedIntegrationEvent.cs
+++ b/src/Services/Basket/Basket.API/IntegrationEvents/Events/OrderStartedIntegrationEvent.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Basket.API.IntegrationEvents.Events
+{
+    // Integration Events notes: 
+    // An Event is “something that has happened in the past”, therefore its name has to be   
+    // An Integration Event is an event that can cause side effects to other microsrvices, Bounded-Contexts or external systems.
+    public class OrderStartedIntegrationEvent : IntegrationEvent
+    {
+        public string UserId { get; }
+
+        public OrderStartedIntegrationEvent(string userId) =>
+            UserId = userId;
+    }
+}

--- a/src/Services/Basket/Basket.API/Startup.cs
+++ b/src/Services/Basket/Basket.API/Startup.cs
@@ -17,6 +17,8 @@ using System;
 using Microsoft.Extensions.HealthChecks;
 using System.Threading.Tasks;
 using Basket.API.Infrastructure.Filters;
+using Basket.API.IntegrationEvents.Events;
+using Basket.API.IntegrationEvents.EventHandling;
 
 namespace Microsoft.eShopOnContainers.Services.Basket.API
 {
@@ -91,6 +93,7 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API
 
             services.AddTransient<IBasketRepository, RedisBasketRepository>();
             services.AddTransient<IIntegrationEventHandler<ProductPriceChangedIntegrationEvent>, ProductPriceChangedIntegrationEventHandler>();
+            services.AddTransient<IIntegrationEventHandler<OrderStartedIntegrationEvent>, OrderStartedIntegrationEventHandler>();
 
             var serviceProvider = services.BuildServiceProvider();
             var configuration = serviceProvider.GetRequiredService<IOptionsSnapshot<BasketSettings>>().Value;
@@ -117,8 +120,10 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API
                 .UseSwaggerUi();
 
             var catalogPriceHandler = app.ApplicationServices.GetService<IIntegrationEventHandler<ProductPriceChangedIntegrationEvent>>();
+            var orderStartedHandler = app.ApplicationServices.GetService<IIntegrationEventHandler<OrderStartedIntegrationEvent>>();
             var eventBus = app.ApplicationServices.GetRequiredService<IEventBus>();
             eventBus.Subscribe<ProductPriceChangedIntegrationEvent>(catalogPriceHandler);
+            eventBus.Subscribe<OrderStartedIntegrationEvent>(orderStartedHandler);
 
         }
 

--- a/src/Services/Catalog/Catalog.API/IntegrationEvents/CatalogIntegrationEventService.cs
+++ b/src/Services/Catalog/Catalog.API/IntegrationEvents/CatalogIntegrationEventService.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Abstractions;
+using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Events;
+using Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF.Services;
+using Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF.Utilities;
+using Microsoft.eShopOnContainers.Services.Catalog.API.Infrastructure;
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+
+namespace Catalog.API.IntegrationEvents
+{
+    public class CatalogIntegrationEventService : ICatalogIntegrationEventService
+    {
+        private readonly Func<DbConnection, IIntegrationEventLogService> _integrationEventLogServiceFactory;
+        private readonly IEventBus _eventBus;
+        private readonly CatalogContext _catalogContext;
+        private readonly IIntegrationEventLogService _eventLogService;
+
+        public CatalogIntegrationEventService(IEventBus eventBus, CatalogContext catalogContext,
+        Func<DbConnection, IIntegrationEventLogService> integrationEventLogServiceFactory)
+        {
+            _catalogContext = catalogContext ?? throw new ArgumentNullException(nameof(catalogContext));
+            _integrationEventLogServiceFactory = integrationEventLogServiceFactory ?? throw new ArgumentNullException(nameof(integrationEventLogServiceFactory));
+            _eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
+            _eventLogService = _integrationEventLogServiceFactory(_catalogContext.Database.GetDbConnection());
+        }
+
+        public async Task PublishAsync(IntegrationEvent evt)
+        {
+            _eventBus.Publish(evt);
+            await _eventLogService.MarkEventAsPublishedAsync(evt);
+        }
+
+        public async Task SaveEventAsync(IntegrationEvent evt)
+        {
+            //Use of an EF Core resiliency strategy when using multiple DbContexts within an explicit BeginTransaction():
+            //See: https://docs.microsoft.com/en-us/ef/core/miscellaneous/connection-resiliency            
+            await ResilientTransaction.New(_catalogContext)
+                .ExecuteAsync(async () => {
+                    // Achieving atomicity between original catalog database operation and the IntegrationEventLog thanks to a local transaction
+                    await _catalogContext.SaveChangesAsync();
+                    await _eventLogService.SaveEventAsync(evt, _catalogContext.Database.CurrentTransaction.GetDbTransaction());
+                });
+        }
+    }
+}

--- a/src/Services/Catalog/Catalog.API/IntegrationEvents/ICatalogIntegrationEventService.cs
+++ b/src/Services/Catalog/Catalog.API/IntegrationEvents/ICatalogIntegrationEventService.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Catalog.API.IntegrationEvents
+{
+    public interface ICatalogIntegrationEventService
+    {
+        Task SaveEventAsync(IntegrationEvent evt);
+        Task PublishAsync(IntegrationEvent evt);
+    }
+}

--- a/src/Services/Catalog/Catalog.API/Startup.cs
+++ b/src/Services/Catalog/Catalog.API/Startup.cs
@@ -20,6 +20,7 @@
     using System.IO;
     using System.Data.Common;
     using System.Reflection;
+    using global::Catalog.API.IntegrationEvents;
 
     public class Startup
     {
@@ -97,10 +98,10 @@
             });
 
             services.AddTransient<Func<DbConnection, IIntegrationEventLogService>>(
-                sp => (DbConnection c) => new IntegrationEventLogService(c));
-
+                sp => (DbConnection c) => new IntegrationEventLogService(c));            
             var serviceProvider = services.BuildServiceProvider();
             var configuration = serviceProvider.GetRequiredService<IOptionsSnapshot<Settings>>().Value;
+            services.AddTransient<ICatalogIntegrationEventService, CatalogIntegrationEventService>();
             services.AddSingleton<IEventBus>(new EventBusRabbitMQ(configuration.EventBusConnection));            
         }
 

--- a/src/Services/Ordering/Ordering.API/Application/DomainEventHandlers/BuyerAndPaymentMethodVerified/UpdateOrderWhenBuyerAndPaymentMethodVerifiedDomainEventHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/DomainEventHandlers/BuyerAndPaymentMethodVerified/UpdateOrderWhenBuyerAndPaymentMethodVerifiedDomainEventHandler.cs
@@ -1,8 +1,15 @@
 ﻿using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Abstractions;
+using Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF.Services;
 using Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.OrderAggregate;
+using Microsoft.eShopOnContainers.Services.Ordering.Infrastructure;
 using Microsoft.Extensions.Logging;
+using Ordering.API.IntegrationEvents.Events;
 using Ordering.Domain.Events;
 using System;
+using System.Data.Common;
 using System.Threading.Tasks;
 
 namespace Ordering.API.Application.DomainEventHandlers.BuyerAndPaymentMethodVerified
@@ -12,9 +19,16 @@ namespace Ordering.API.Application.DomainEventHandlers.BuyerAndPaymentMethodVeri
     {
         private readonly IOrderRepository _orderRepository;
         private readonly ILoggerFactory _logger;
-        public UpdateOrderWhenBuyerAndPaymentMethodVerifiedDomainEventHandler(IOrderRepository orderRepository, ILoggerFactory logger)
+        private readonly Func<DbConnection, IIntegrationEventLogService> _integrationEventLogServiceFactory;
+        private readonly IEventBus _eventBus;
+
+        public UpdateOrderWhenBuyerAndPaymentMethodVerifiedDomainEventHandler(
+            IOrderRepository orderRepository, ILoggerFactory logger, IEventBus eventBus,
+            Func<DbConnection, IIntegrationEventLogService> integrationEventLogServiceFactory)
         {
             _orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+            _integrationEventLogServiceFactory = integrationEventLogServiceFactory ?? throw new ArgumentNullException(nameof(integrationEventLogServiceFactory));
+            _eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -26,12 +40,30 @@ namespace Ordering.API.Application.DomainEventHandlers.BuyerAndPaymentMethodVeri
             var orderToUpdate = await _orderRepository.GetAsync(buyerPaymentMethodVerifiedEvent.OrderId);
             orderToUpdate.SetBuyerId(buyerPaymentMethodVerifiedEvent.Buyer.Id);
             orderToUpdate.SetPaymentId(buyerPaymentMethodVerifiedEvent.Payment.Id);
-            
-            await _orderRepository.UnitOfWork
-                .SaveEntitiesAsync();
-                                       
+                                    
+            var orderStartedIntegrationEvent = new OrderStartedIntegrationEvent(buyerPaymentMethodVerifiedEvent.Buyer.IdentityGuid);
+            //Use of an EF Core resiliency strategy when using multiple DbContexts within an explicit BeginTransaction():
+            //See: https://docs.microsoft.com/en-us/ef/core/miscellaneous/connection-resiliency
+            var orderingContext = _orderRepository.UnitOfWork as OrderingContext;
+            var strategy = orderingContext.Database.CreateExecutionStrategy();
+
+            var eventLogService = _integrationEventLogServiceFactory(orderingContext.Database.GetDbConnection());
+            await strategy.ExecuteAsync(async () =>
+            {
+            // Achieving atomicity between original Catalog database operation and the IntegrationEventLog thanks to a local transaction
+            using (var transaction = orderingContext.Database.BeginTransaction())
+                {
+                    await _orderRepository.UnitOfWork.SaveEntitiesAsync();
+                    await eventLogService.SaveEventAsync(orderStartedIntegrationEvent, orderingContext.Database.CurrentTransaction.GetDbTransaction());
+                    transaction.Commit();
+                }
+            });
+
             _logger.CreateLogger(nameof(UpdateOrderWhenBuyerAndPaymentMethodVerifiedDomainEventHandler))
                 .LogTrace($"Order with Id: {buyerPaymentMethodVerifiedEvent.OrderId} has been successfully updated with a payment method id: { buyerPaymentMethodVerifiedEvent.Payment.Id }");
+
+            _eventBus.Publish(orderStartedIntegrationEvent);
+            await eventLogService.MarkEventAsPublishedAsync(orderStartedIntegrationEvent);            
         }
-    }
+    }  
 }

--- a/src/Services/Ordering/Ordering.API/Infrastructure/AutofacModules/MediatorModule.cs
+++ b/src/Services/Ordering/Ordering.API/Infrastructure/AutofacModules/MediatorModule.cs
@@ -31,7 +31,8 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.API.Infrastructure.Autof
             builder.RegisterAssemblyTypes(typeof(ValidateOrAddBuyerAggregateWhenOrderStartedDomainEventHandler).GetTypeInfo().Assembly)
                 .As(o => o.GetInterfaces()
                     .Where(i => i.IsClosedTypeOf(typeof(IAsyncNotificationHandler<>)))
-                    .Select(i => new KeyedService("IAsyncNotificationHandler", i)));
+                    .Select(i => new KeyedService("IAsyncNotificationHandler", i)))
+                    .AsImplementedInterfaces();
 
             builder
                 .RegisterAssemblyTypes(typeof(CreateOrderCommandValidator).GetTypeInfo().Assembly)

--- a/src/Services/Ordering/Ordering.API/Infrastructure/IntegrationEventMigrations/20170330131634_IntegrationEventInitial.Designer.cs
+++ b/src/Services/Ordering/Ordering.API/Infrastructure/IntegrationEventMigrations/20170330131634_IntegrationEventInitial.Designer.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF;
+
+namespace Ordering.API.Infrastructure.IntegrationEventMigrations
+{
+    [DbContext(typeof(IntegrationEventLogContext))]
+    [Migration("20170330131634_IntegrationEventInitial")]
+    partial class IntegrationEventInitial
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.1.1")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF.IntegrationEventLogEntry", b =>
+                {
+                    b.Property<Guid>("EventId")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Content")
+                        .IsRequired();
+
+                    b.Property<DateTime>("CreationTime");
+
+                    b.Property<string>("EventTypeName")
+                        .IsRequired();
+
+                    b.Property<int>("State");
+
+                    b.Property<int>("TimesSent");
+
+                    b.HasKey("EventId");
+
+                    b.ToTable("IntegrationEventLog");
+                });
+        }
+    }
+}

--- a/src/Services/Ordering/Ordering.API/Infrastructure/IntegrationEventMigrations/20170330131634_IntegrationEventInitial.cs
+++ b/src/Services/Ordering/Ordering.API/Infrastructure/IntegrationEventMigrations/20170330131634_IntegrationEventInitial.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Ordering.API.Infrastructure.IntegrationEventMigrations
+{
+    public partial class IntegrationEventInitial : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "IntegrationEventLog",
+                columns: table => new
+                {
+                    EventId = table.Column<Guid>(nullable: false),
+                    Content = table.Column<string>(nullable: false),
+                    CreationTime = table.Column<DateTime>(nullable: false),
+                    EventTypeName = table.Column<string>(nullable: false),
+                    State = table.Column<int>(nullable: false),
+                    TimesSent = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IntegrationEventLog", x => x.EventId);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "IntegrationEventLog");
+        }
+    }
+}

--- a/src/Services/Ordering/Ordering.API/Infrastructure/IntegrationEventMigrations/IntegrationEventLogContextModelSnapshot.cs
+++ b/src/Services/Ordering/Ordering.API/Infrastructure/IntegrationEventMigrations/IntegrationEventLogContextModelSnapshot.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF;
+
+namespace Ordering.API.Infrastructure.IntegrationEventMigrations
+{
+    [DbContext(typeof(IntegrationEventLogContext))]
+    partial class IntegrationEventLogContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.1.1")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF.IntegrationEventLogEntry", b =>
+                {
+                    b.Property<Guid>("EventId")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Content")
+                        .IsRequired();
+
+                    b.Property<DateTime>("CreationTime");
+
+                    b.Property<string>("EventTypeName")
+                        .IsRequired();
+
+                    b.Property<int>("State");
+
+                    b.Property<int>("TimesSent");
+
+                    b.HasKey("EventId");
+
+                    b.ToTable("IntegrationEventLog");
+                });
+        }
+    }
+}

--- a/src/Services/Ordering/Ordering.API/IntegrationEvents/Events/OrderStartedIntegrationEvent.cs
+++ b/src/Services/Ordering/Ordering.API/IntegrationEvents/Events/OrderStartedIntegrationEvent.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Ordering.API.IntegrationEvents.Events
+{
+    // Integration Events notes: 
+    // An Event is “something that has happened in the past”, therefore its name has to be   
+    // An Integration Event is an event that can cause side effects to other microsrvices, Bounded-Contexts or external systems.
+    public class OrderStartedIntegrationEvent : IntegrationEvent
+    {
+        public string UserId { get; }
+
+        public OrderStartedIntegrationEvent(string userId) =>
+            UserId = userId;
+    }
+}

--- a/src/Services/Ordering/Ordering.API/IntegrationEvents/IOrderingIntegrationEventService.cs
+++ b/src/Services/Ordering/Ordering.API/IntegrationEvents/IOrderingIntegrationEventService.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Ordering.API.IntegrationEvents
+{
+    public interface IOrderingIntegrationEventService
+    {
+        Task SaveEventAsync(IntegrationEvent evt);
+        Task PublishAsync(IntegrationEvent evt);
+    }
+}

--- a/src/Services/Ordering/Ordering.API/IntegrationEvents/OrderingIntegrationEventService.cs
+++ b/src/Services/Ordering/Ordering.API/IntegrationEvents/OrderingIntegrationEventService.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Abstractions;
+using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Events;
+using Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF.Services;
+using Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF.Utilities;
+using Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.OrderAggregate;
+using Microsoft.eShopOnContainers.Services.Ordering.Infrastructure;
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+
+namespace Ordering.API.IntegrationEvents
+{
+    public class OrderingIntegrationEventService : IOrderingIntegrationEventService
+    {
+        private readonly Func<DbConnection, IIntegrationEventLogService> _integrationEventLogServiceFactory;
+        private readonly IEventBus _eventBus;
+        private readonly OrderingContext _orderingContext;
+        private readonly IIntegrationEventLogService _eventLogService;
+
+        public OrderingIntegrationEventService (IEventBus eventBus, OrderingContext orderingContext,
+        Func<DbConnection, IIntegrationEventLogService> integrationEventLogServiceFactory)
+        {
+            _orderingContext = orderingContext ?? throw new ArgumentNullException(nameof(orderingContext));
+            _integrationEventLogServiceFactory = integrationEventLogServiceFactory ?? throw new ArgumentNullException(nameof(integrationEventLogServiceFactory));
+            _eventBus = eventBus ?? throw new ArgumentNullException(nameof(eventBus));
+            _eventLogService = _integrationEventLogServiceFactory(_orderingContext.Database.GetDbConnection());
+        }
+
+        public async Task PublishAsync(IntegrationEvent evt)
+        {
+            _eventBus.Publish(evt);
+            await _eventLogService.MarkEventAsPublishedAsync(evt);
+        }
+
+        public async Task SaveEventAsync(IntegrationEvent evt)
+        {
+            //Use of an EF Core resiliency strategy when using multiple DbContexts within an explicit BeginTransaction():
+            //See: https://docs.microsoft.com/en-us/ef/core/miscellaneous/connection-resiliency            
+            await ResilientTransaction.New(_orderingContext)
+                .ExecuteAsync(async () => {
+                    // Achieving atomicity between original ordering database operation and the IntegrationEventLog thanks to a local transaction
+                    await _orderingContext.SaveChangesAsync();
+                    await _eventLogService.SaveEventAsync(evt, _orderingContext.Database.CurrentTransaction.GetDbTransaction());
+                });
+        }
+    }
+}

--- a/src/Services/Ordering/Ordering.API/Ordering.API.csproj
+++ b/src/Services/Ordering/Ordering.API/Ordering.API.csproj
@@ -23,6 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBusRabbitMQ\EventBusRabbitMQ.csproj" />
+    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\EventBus\EventBus.csproj" />
+    <ProjectReference Include="..\..\..\BuildingBlocks\EventBus\IntegrationEventLogEF\IntegrationEventLogEF.csproj" />
     <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.AspNetCore.HealthChecks\Microsoft.AspNetCore.HealthChecks.csproj" />
     <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks.Data\Microsoft.Extensions.HealthChecks.Data.csproj" />
     <ProjectReference Include="..\..\..\BuildingBlocks\HealthChecks\src\Microsoft.Extensions.HealthChecks\Microsoft.Extensions.HealthChecks.csproj" />
@@ -38,16 +41,18 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.0" />
@@ -71,6 +76,11 @@
     <None Update="Dockerfile">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Infrastructure\IntegrationEventMigrations\" />
+    <Folder Include="IntegrationEvents\EventHandling\" />
   </ItemGroup>
 
 </Project>

--- a/src/Services/Ordering/Ordering.API/Startup.cs
+++ b/src/Services/Ordering/Ordering.API/Startup.cs
@@ -4,6 +4,7 @@
     using Autofac;
     using Autofac.Extensions.DependencyInjection;
     using global::Ordering.API.Infrastructure.Middlewares;
+    using global::Ordering.API.IntegrationEvents;
     using Infrastructure;
     using Infrastructure.Auth;
     using Infrastructure.AutofacModules;
@@ -101,9 +102,9 @@
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddTransient<IIdentityService, IdentityService>();
             services.AddTransient<Func<DbConnection, IIntegrationEventLogService>>(
-                sp => (DbConnection c) => new IntegrationEventLogService(c));
-
+                sp => (DbConnection c) => new IntegrationEventLogService(c));            
             var serviceProvider = services.BuildServiceProvider();
+            services.AddTransient<IOrderingIntegrationEventService, OrderingIntegrationEventService>();
             services.AddSingleton<IEventBus>(new EventBusRabbitMQ(Configuration["EventBusConnection"]));
             services.AddOptions();
 

--- a/src/Services/Ordering/Ordering.Infrastructure/Ordering.Infrastructure.csproj
+++ b/src/Services/Ordering/Ordering.Infrastructure/Ordering.Infrastructure.csproj
@@ -16,8 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Web/WebMVC/Controllers/OrderController.cs
+++ b/src/Web/WebMVC/Controllers/OrderController.cs
@@ -45,9 +45,6 @@ namespace Microsoft.eShopOnContainers.WebMVC.Controllers
                     var user = _appUserParser.Parse(HttpContext.User);
                     await _orderSvc.CreateOrder(model);
 
-                    //Empty basket for current user. 
-                    await _basketSvc.CleanBasket(user);
-
                     //Redirect to historic list.
                     return RedirectToAction("Index");
                 }


### PR DESCRIPTION
Removed clean basket call from Mvc WebApp. Now the clean basket instruction is raised by an integration event from Ordering.Api to Basket.Api when a new order is created.