### PR TITLE
Idsvr new config

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -33,6 +33,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://0.0.0.0:5105
       - SpaClient=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5104
+      - XamarinCallback=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5105
       - ConnectionStrings__DefaultConnection=Server=sql.data;Database=Microsoft.eShopOnContainers.Service.IdentityDb;User Id=sa;Password=Pass@word 
       - MvcClient=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5100              #Local: You need to open your local dev-machine firewall at range 5100-5105.  
     ports:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -33,7 +33,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://0.0.0.0:5105
       - SpaClient=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5104
-      - XamarinCallback=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5105
+      - XamarinCallback=http://${ESHOP_PROD_EXTERNAL_DNS_NAME_OR_IP}:5105/xamarincallback      #localhost do not work for UWP login, so we have to use "external" IP always
       - ConnectionStrings__DefaultConnection=Server=sql.data;Database=Microsoft.eShopOnContainers.Service.IdentityDb;User Id=sa;Password=Pass@word 
       - MvcClient=http://${ESHOP_EXTERNAL_DNS_NAME_OR_IP}:5100              #Local: You need to open your local dev-machine firewall at range 5100-5105.  
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,6 +38,7 @@ services:
       - SpaClient=http://${ESHOP_PROD_EXTERNAL_DNS_NAME_OR_IP}:5104
       - ConnectionStrings__DefaultConnection=Server=sql.data;Database=Microsoft.eShopOnContainers.Service.IdentityDb;User Id=sa;Password=Pass@word 
       - MvcClient=http://${ESHOP_PROD_EXTERNAL_DNS_NAME_OR_IP}:5100              #Local: You need to open your host's firewall at range 5100-5105.  
+      - XamarinCallback=http://${ESHOP_PROD_EXTERNAL_DNS_NAME_OR_IP}:5105
     ports:
       - "5105:5105"
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,7 +38,7 @@ services:
       - SpaClient=http://${ESHOP_PROD_EXTERNAL_DNS_NAME_OR_IP}:5104
       - ConnectionStrings__DefaultConnection=Server=sql.data;Database=Microsoft.eShopOnContainers.Service.IdentityDb;User Id=sa;Password=Pass@word 
       - MvcClient=http://${ESHOP_PROD_EXTERNAL_DNS_NAME_OR_IP}:5100              #Local: You need to open your host's firewall at range 5100-5105.  
-      - XamarinCallback=http://${ESHOP_PROD_EXTERNAL_DNS_NAME_OR_IP}:5105
+      - XamarinCallback=http://${ESHOP_PROD_EXTERNAL_DNS_NAME_OR_IP}:5105/xamarincallback
     ports:
       - "5105:5105"
 

--- a/src/Services/Identity/Identity.API/Configuration/Config.cs
+++ b/src/Services/Identity/Identity.API/Configuration/Config.cs
@@ -59,7 +59,7 @@ namespace Identity.API.Configuration
                     ClientName = "eShop Xamarin OpenId Client",
                     AllowedGrantTypes = GrantTypes.Implicit,
                     AllowAccessTokensViaBrowser = true,
-                    RedirectUris =           { "http://eshopxamarin/callback.html" },
+                    RedirectUris =          { $"{clientsUrl["Xamarin"]}/" },
                     RequireConsent = false,
                     PostLogoutRedirectUris = { "http://13.88.8.119:5105/Account/Redirecting", "http://10.6.1.234:5105/Account/Redirecting" },
                     AllowedCorsOrigins =     { "http://eshopxamarin" },

--- a/src/Services/Identity/Identity.API/Configuration/Config.cs
+++ b/src/Services/Identity/Identity.API/Configuration/Config.cs
@@ -59,7 +59,7 @@ namespace Identity.API.Configuration
                     ClientName = "eShop Xamarin OpenId Client",
                     AllowedGrantTypes = GrantTypes.Implicit,
                     AllowAccessTokensViaBrowser = true,
-                    RedirectUris =          { $"{clientsUrl["Xamarin"]}/" },
+                    RedirectUris =          { clientsUrl["Xamarin"] },
                     RequireConsent = false,
                     PostLogoutRedirectUris = { "http://13.88.8.119:5105/Account/Redirecting", "http://10.6.1.234:5105/Account/Redirecting" },
                     AllowedCorsOrigins =     { "http://eshopxamarin" },

--- a/src/Services/Identity/Identity.API/Startup.cs
+++ b/src/Services/Identity/Identity.API/Startup.cs
@@ -73,6 +73,7 @@ namespace eShopOnContainers.Identity
             Dictionary<string, string> clientUrls = new Dictionary<string, string>();
             clientUrls.Add("Mvc", Configuration.GetValue<string>("MvcClient"));
             clientUrls.Add("Spa", Configuration.GetValue<string>("SpaClient"));
+            clientUrls.Add("Xamarin", Configuration.GetValue<string>("XamarinCallback"));
 
             // Adds IdentityServer
             services.AddIdentityServer(x => x.IssuerUri = "null")

--- a/src/Services/Identity/Identity.API/appsettings.json
+++ b/src/Services/Identity/Identity.API/appsettings.json
@@ -4,7 +4,7 @@
   },
   "MvcClient": "http://localhost:5100",
   "SpaClient": "http://localhost:5104",
-  "XamarinCallback":  "http://localhost:5105",
+  "XamarinCallback":  "http://localhost:5105/xamarincallback",
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {

--- a/src/Services/Identity/Identity.API/appsettings.json
+++ b/src/Services/Identity/Identity.API/appsettings.json
@@ -4,6 +4,7 @@
   },
   "MvcClient": "http://localhost:5100",
   "SpaClient": "http://localhost:5104",
+  "XamarinCallback":  "http://localhost:5105",
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {


### PR DESCRIPTION
This PR solves the issues detected in Xamarin UWP application on signin.
Basically, if the origin of the OIDC "Callback URL" do not exist, UWP's WebView do not raise any event, and the Xamarin app can't know that the signin process has finished. This do not happen on Android nor iOS. Only UWP.

So, Xamarin app configuration was updated to use a existing origin (same as IdSvr) and IdSvr config was updated to allow this new callbackurl.
The new callbackurl is xxxx/xamarincallback, where xxxx is the IdSvr origin (host+port).

Note that localhost is not valid, because Webview complains about it also, so if you are running services in your machine, you must use your IP.
Docker-compose files have been udpated to enforce this.
