### PR TITLE
.net core 2.0 packages update and some warnings fixed

### DIFF
--- a/src/BuildingBlocks/DataProtection/DataProtection/DataProtection.csproj
+++ b/src/BuildingBlocks/DataProtection/DataProtection/DataProtection.csproj
@@ -3,17 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.5</TargetFramework>
     <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks</RootNamespace>
-    <!--
-    <NetStandardImplicitPackageVersion>2.0.0-preview1-25301-01</NetStandardImplicitPackageVersion>
-    -->
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="1.1.2" />
-    <!--
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.0.0-preview2-final" />
-    -->
-    <PackageReference Include="StackExchange.Redis" Version="1.2.3" />
   </ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/EventBus/EventBus.Tests/EventBus.Tests.csproj
+++ b/src/BuildingBlocks/EventBus/EventBus.Tests/EventBus.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/src/BuildingBlocks/EventBus/EventBus.Tests/TestIntegrationEventHandler.cs
+++ b/src/BuildingBlocks/EventBus/EventBus.Tests/TestIntegrationEventHandler.cs
@@ -1,7 +1,4 @@
 ﻿using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Abstractions;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace EventBus.Tests

--- a/src/BuildingBlocks/EventBus/EventBus.Tests/TestIntegrationOtherEventHandler.cs
+++ b/src/BuildingBlocks/EventBus/EventBus.Tests/TestIntegrationOtherEventHandler.cs
@@ -1,7 +1,4 @@
 ﻿using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Abstractions;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace EventBus.Tests

--- a/src/BuildingBlocks/EventBus/EventBus/EventBus.csproj
+++ b/src/BuildingBlocks/EventBus/EventBus/EventBus.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBus</RootNamespace>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="Abstractions\" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.cs
+++ b/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.cs
@@ -184,7 +184,7 @@ namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBusRabbitMQ
             };
 
             channel.BasicConsume(queue: _queueName,
-                                 noAck: true,
+                                 autoAck: true,
                                  consumer: consumer);
 
             channel.CallbackException += (sender, ea) =>

--- a/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.csproj
+++ b/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBusRabbitMQ</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
+    <PackageReference Include="Autofac" Version="4.6.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Polly" Version="5.2.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="4.1.3" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="Polly" Version="5.3.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.csproj
+++ b/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBusServiceBus</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.5.0" />
+    <PackageReference Include="Autofac" Version="4.6.1" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuildingBlocks/EventBus/IntegrationEventLogEF/IntegrationEventLogEF.csproj
+++ b/src/BuildingBlocks/EventBus/IntegrationEventLogEF/IntegrationEventLogEF.csproj
@@ -6,12 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 

--- a/src/BuildingBlocks/HealthChecks/src/Microsoft.Extensions.HealthChecks.AzureStorage/Microsoft.Extensions.HealthChecks.AzureStorage.csproj
+++ b/src/BuildingBlocks/HealthChecks/src/Microsoft.Extensions.HealthChecks.AzureStorage/Microsoft.Extensions.HealthChecks.AzureStorage.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
-    <PackageTargetFallback>$(PackageTargetFallback);net46</PackageTargetFallback>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -17,11 +16,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="7.2.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
+    <PackageReference Include="WindowsAzure.Storage" Version="8.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/HealthChecks/src/Microsoft.Extensions.HealthChecks.SqlServer/Microsoft.Extensions.HealthChecks.SqlServer.csproj
+++ b/src/BuildingBlocks/HealthChecks/src/Microsoft.Extensions.HealthChecks.SqlServer/Microsoft.Extensions.HealthChecks.SqlServer.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.3.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuildingBlocks/Resilience/Resilience.Http/Resilience.Http.csproj
+++ b/src/BuildingBlocks/Resilience/Resilience.Http/Resilience.Http.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.Resilience.Http</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Polly" Version="5.2.0" />
+    <PackageReference Include="Polly" Version="5.3.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Services/Basket/Basket.API/Basket.API.csproj
+++ b/src/Services/Basket/Basket.API/Basket.API.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="1.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="1.0.0" />
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
-    <PackageReference Include="StackExchange.Redis" Version="1.2.3" />
+    <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="1.2.1" />
   </ItemGroup>

--- a/src/Services/Basket/Basket.API/Controllers/BasketController.cs
+++ b/src/Services/Basket/Basket.API/Controllers/BasketController.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.eShopOnContainers.Services.Basket.API.Model;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Abstractions;
 using Basket.API.IntegrationEvents.Events;
 using Microsoft.eShopOnContainers.Services.Basket.API.Services;

--- a/src/Services/Basket/Basket.API/Dockerfile.nanowin
+++ b/src/Services/Basket/Basket.API/Dockerfile.nanowin
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1-runtime-nanoserver
+FROM microsoft/dotnet:2.0-runtime-nanoserver
 SHELL ["powershell"]
 ARG source
 WORKDIR /app

--- a/src/Services/Basket/Basket.API/Infrastructure/Exceptions/BasketDomainException.cs
+++ b/src/Services/Basket/Basket.API/Infrastructure/Exceptions/BasketDomainException.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Basket.API.Infrastructure.Exceptions
 {

--- a/src/Services/Basket/Basket.API/Infrastructure/Exceptions/FailingMiddlewareAppBuilderExtensions.cs
+++ b/src/Services/Basket/Basket.API/Infrastructure/Exceptions/FailingMiddlewareAppBuilderExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Basket.API.Infrastructure.Middlewares
 {

--- a/src/Services/Basket/Basket.API/Infrastructure/Filters/AuthorizeCheckOperationFilter.cs
+++ b/src/Services/Basket/Basket.API/Infrastructure/Filters/AuthorizeCheckOperationFilter.cs
@@ -1,10 +1,8 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace Basket.API.Infrastructure.Filters
 {

--- a/src/Services/Basket/Basket.API/Infrastructure/Middlewares/FailingMiddleware.cs
+++ b/src/Services/Basket/Basket.API/Infrastructure/Middlewares/FailingMiddleware.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/Services/Basket/Basket.API/Infrastructure/Middlewares/FailingOptions.cs
+++ b/src/Services/Basket/Basket.API/Infrastructure/Middlewares/FailingOptions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Basket.API.Infrastructure.Middlewares
 {

--- a/src/Services/Basket/Basket.API/IntegrationEvents/EventHandling/OrderStartedIntegrationEventHandler.cs
+++ b/src/Services/Basket/Basket.API/IntegrationEvents/EventHandling/OrderStartedIntegrationEventHandler.cs
@@ -1,6 +1,5 @@
 ﻿using Basket.API.IntegrationEvents.Events;
 using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Abstractions;
-using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Events;
 using Microsoft.eShopOnContainers.Services.Basket.API.Model;
 using System;
 using System.Threading.Tasks;
@@ -22,6 +21,3 @@ namespace Basket.API.IntegrationEvents.EventHandling
         }
     }
 }
-
-
-

--- a/src/Services/Basket/Basket.API/IntegrationEvents/Events/UserCheckoutAcceptedIntegrationEvent.cs
+++ b/src/Services/Basket/Basket.API/IntegrationEvents/Events/UserCheckoutAcceptedIntegrationEvent.cs
@@ -1,9 +1,6 @@
 ﻿using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Events;
 using Microsoft.eShopOnContainers.Services.Basket.API.Model;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Basket.API.IntegrationEvents.Events
 {

--- a/src/Services/Basket/Basket.API/Model/BasketCheckout.cs
+++ b/src/Services/Basket/Basket.API/Model/BasketCheckout.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Basket.API.Model
 {

--- a/src/Services/Basket/Basket.API/Program.cs
+++ b/src/Services/Basket/Basket.API/Program.cs
@@ -1,7 +1,6 @@
 ﻿using Basket.API.Infrastructure.Middlewares;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.eShopOnContainers.Services.Basket.API

--- a/src/Services/Basket/Basket.API/Startup.cs
+++ b/src/Services/Basket/Basket.API/Startup.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.eShopOnContainers.BuildingBlocks.EventBus;
 using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Abstractions;
 using Microsoft.eShopOnContainers.BuildingBlocks.EventBusRabbitMQ;
-using Microsoft.eShopOnContainers.Services.Basket.API.Auth.Server;
 using Microsoft.eShopOnContainers.Services.Basket.API.IntegrationEvents.EventHandling;
 using Microsoft.eShopOnContainers.Services.Basket.API.IntegrationEvents.Events;
 using Microsoft.eShopOnContainers.Services.Basket.API.Model;
@@ -22,8 +21,6 @@ using Microsoft.Extensions.Options;
 using RabbitMQ.Client;
 using StackExchange.Redis;
 using System;
-using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 
 using Microsoft.eShopOnContainers.BuildingBlocks.EventBusServiceBus;

--- a/src/Services/Catalog/Catalog.API/Catalog.API.csproj
+++ b/src/Services/Catalog/Catalog.API/Catalog.API.csproj
@@ -32,7 +32,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="2.0.0" />

--- a/src/Services/Catalog/Catalog.API/Controllers/HomeController.cs
+++ b/src/Services/Catalog/Catalog.API/Controllers/HomeController.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 
-// For more information on enabling MVC for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
-
 namespace Microsoft.eShopOnContainers.Services.Catalog.API.Controllers
 {
     public class HomeController : Controller

--- a/src/Services/Catalog/Catalog.API/Controllers/PicController.cs
+++ b/src/Services/Catalog/Catalog.API/Controllers/PicController.cs
@@ -5,8 +5,6 @@ using Microsoft.eShopOnContainers.Services.Catalog.API.Infrastructure;
 using System.IO;
 using System.Threading.Tasks;
 
-// For more information on enabling MVC for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
-
 namespace Microsoft.eShopOnContainers.Services.Catalog.API.Controllers
 {
     public class PicController : Controller
@@ -23,7 +21,6 @@ namespace Microsoft.eShopOnContainers.Services.Catalog.API.Controllers
 
         [HttpGet]
         [Route("api/v1/catalog/items/{catalogItemId:int}/pic")]
-        // GET: /<controller>/
         public async Task<IActionResult> GetImage(int catalogItemId)
         {
             if (catalogItemId <= 0)

--- a/src/Services/Catalog/Catalog.API/Dockerfile.nanowin
+++ b/src/Services/Catalog/Catalog.API/Dockerfile.nanowin
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1-runtime-nanoserver 
+FROM microsoft/dotnet:2.0-runtime-nanoserver
 SHELL ["powershell"]
 ARG source
 WORKDIR /app

--- a/src/Services/Catalog/Catalog.API/Infrastructure/CatalogContext.cs
+++ b/src/Services/Catalog/Catalog.API/Infrastructure/CatalogContext.cs
@@ -3,7 +3,6 @@
     using EntityFrameworkCore.Metadata.Builders;
     using Microsoft.EntityFrameworkCore;
     using Model;
-    using Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF;
 
     public class CatalogContext : DbContext
     {

--- a/src/Services/Catalog/Catalog.API/Infrastructure/IntegrationEventMigrations/IntegrationEventLogContextModelSnapshot.cs
+++ b/src/Services/Catalog/Catalog.API/Infrastructure/IntegrationEventMigrations/IntegrationEventLogContextModelSnapshot.cs
@@ -2,7 +2,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF;
 
 namespace Catalog.API.Migrations

--- a/src/Services/Catalog/Catalog.API/Startup.cs
+++ b/src/Services/Catalog/Catalog.API/Startup.cs
@@ -9,7 +9,6 @@
     using Microsoft.Azure.ServiceBus;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.Diagnostics;
-    using Microsoft.EntityFrameworkCore.Infrastructure;
     using Microsoft.eShopOnContainers.BuildingBlocks.EventBus;
     using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Abstractions;
     using Microsoft.eShopOnContainers.BuildingBlocks.EventBusRabbitMQ;
@@ -24,8 +23,6 @@
     using Microsoft.Extensions.HealthChecks;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
-    using Microsoft.WindowsAzure.Storage;
-    using Microsoft.WindowsAzure.Storage.Auth;
     using Polly;
     using RabbitMQ.Client;
     using System;

--- a/src/Services/Identity/Identity.API/Data/ApplicationDbContext.cs
+++ b/src/Services/Identity/Identity.API/Data/ApplicationDbContext.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Identity.API.Models;
 

--- a/src/Services/Identity/Identity.API/Models/ApplicationUser.cs
+++ b/src/Services/Identity/Identity.API/Models/ApplicationUser.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
-using System.ComponentModel.DataAnnotations;
 
 namespace Identity.API.Models
 {

--- a/src/Services/Identity/Identity.API/Services/EFLoginService.cs
+++ b/src/Services/Identity/Identity.API/Services/EFLoginService.cs
@@ -1,8 +1,5 @@
 ﻿using Identity.API.Models;
 using Microsoft.AspNetCore.Identity;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Identity.API.Services

--- a/src/Services/Identity/Identity.API/Services/IEmailSender.cs
+++ b/src/Services/Identity/Identity.API/Services/IEmailSender.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Identity.API.Services
 {

--- a/src/Services/Identity/Identity.API/Services/ILoginService.cs
+++ b/src/Services/Identity/Identity.API/Services/ILoginService.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Identity.API.Services
 {

--- a/src/Services/Identity/Identity.API/Services/IRedirectService.cs
+++ b/src/Services/Identity/Identity.API/Services/IRedirectService.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Identity.API.Services
+﻿namespace Identity.API.Services
 {
     public interface IRedirectService
     {

--- a/src/Services/Identity/Identity.API/Services/ISmsSender.cs
+++ b/src/Services/Identity/Identity.API/Services/ISmsSender.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Identity.API.Services
 {

--- a/src/Services/Identity/Identity.API/Services/MessageServices.cs
+++ b/src/Services/Identity/Identity.API/Services/MessageServices.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Identity.API.Services
 {

--- a/src/Services/Identity/Identity.API/Startup.cs
+++ b/src/Services/Identity/Identity.API/Startup.cs
@@ -16,7 +16,6 @@ using Microsoft.eShopOnContainers.Services.Catalog.API.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.HealthChecks;
-using Identity.API.Certificate;
 using Autofac.Extensions.DependencyInjection;
 using Autofac;
 using Microsoft.Extensions.Logging;
@@ -159,14 +158,16 @@ namespace eShopOnContainers.Identity
         private async Task InitializeGrantStoreAndConfiguration(IApplicationBuilder app)
         {
             //callbacks urls from config:
-            Dictionary<string, string> clientUrls = new Dictionary<string, string>();
-            clientUrls.Add("Mvc", Configuration.GetValue<string>("MvcClient"));
-            clientUrls.Add("Spa", Configuration.GetValue<string>("SpaClient"));
-            clientUrls.Add("Xamarin", Configuration.GetValue<string>("XamarinCallback"));
-            clientUrls.Add("LocationsApi", Configuration.GetValue<string>("LocationApiClient"));
-            clientUrls.Add("MarketingApi", Configuration.GetValue<string>("MarketingApiClient"));
-            clientUrls.Add("BasketApi", Configuration.GetValue<string>("BasketApiClient"));
-            clientUrls.Add("OrderingApi", Configuration.GetValue<string>("OrderingApiClient"));
+            Dictionary<string, string> clientUrls = new Dictionary<string, string>
+            {
+                { "Mvc", Configuration.GetValue<string>("MvcClient") },
+                { "Spa", Configuration.GetValue<string>("SpaClient") },
+                { "Xamarin", Configuration.GetValue<string>("XamarinCallback") },
+                { "LocationsApi", Configuration.GetValue<string>("LocationApiClient") },
+                { "MarketingApi", Configuration.GetValue<string>("MarketingApiClient") },
+                { "BasketApi", Configuration.GetValue<string>("BasketApiClient") },
+                { "OrderingApi", Configuration.GetValue<string>("OrderingApiClient") }
+            };
 
             using (var serviceScope = app.ApplicationServices.GetService<IServiceScopeFactory>().CreateScope())
             {

--- a/src/Services/Location/Locations.API/Dockerfile.nanowin
+++ b/src/Services/Location/Locations.API/Dockerfile.nanowin
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:1.1-runtime-nanoserver
+FROM microsoft/dotnet:2.0-runtime-nanoserver
 SHELL ["powershell"]
 ARG source
 WORKDIR /app
 RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord
 EXPOSE 80
 COPY ${source:-obj/Docker/publish} .
-ENTRYPOINT ["dotnet", "Basket.API.dll"]
+ENTRYPOINT ["dotnet", "Locations.API.dll"]

--- a/src/Services/Location/Locations.API/Locations.API.csproj
+++ b/src/Services/Location/Locations.API/Locations.API.csproj
@@ -7,12 +7,8 @@
     <UserSecretsId>aspnet-Locations.API-20161122013619</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="1.2.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.0-beta6" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
@@ -20,7 +16,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />

--- a/src/Services/Marketing/Marketing.API/Dockerfile.nanowin
+++ b/src/Services/Marketing/Marketing.API/Dockerfile.nanowin
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:1.1-runtime-nanoserver
+FROM microsoft/dotnet:2.0-runtime-nanoserver
 SHELL ["powershell"]
 ARG source
 WORKDIR /app
 RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord
 EXPOSE 80
 COPY ${source:-obj/Docker/publish} .
-ENTRYPOINT ["dotnet", "Basket.API.dll"]
+ENTRYPOINT ["dotnet", "Marketing.API.dll"]

--- a/src/Services/Marketing/Marketing.API/IntegrationEvents/Handlers/UserLocationUpdatedIntegrationEventHandler.cs
+++ b/src/Services/Marketing/Marketing.API/IntegrationEvents/Handlers/UserLocationUpdatedIntegrationEventHandler.cs
@@ -4,7 +4,6 @@
     using Marketing.API.Model;
     using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Abstractions;
     using Microsoft.eShopOnContainers.Services.Marketing.API.Infrastructure.Repositories;
-    using Microsoft.eShopOnContainers.Services.Marketing.API.Model;
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;

--- a/src/Services/Marketing/Marketing.API/Marketing.API.csproj
+++ b/src/Services/Marketing/Marketing.API/Marketing.API.csproj
@@ -17,7 +17,7 @@
     <Folder Include="Infrastructure\MarketingMigrations\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="1.2.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />

--- a/src/Services/Ordering/Ordering.API/Dockerfile.nanowin
+++ b/src/Services/Ordering/Ordering.API/Dockerfile.nanowin
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1-runtime-nanoserver
+FROM microsoft/dotnet:2.0-runtime-nanoserver
 SHELL ["powershell"]
 ARG source
 WORKDIR /app

--- a/src/Services/Ordering/Ordering.API/Ordering.API.csproj
+++ b/src/Services/Ordering/Ordering.API/Ordering.API.csproj
@@ -32,10 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="7.0.3" />
-    <PackageReference Include="FluentValidation.MVC6" Version="6.4.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="7.1.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="3.0.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
@@ -53,15 +52,14 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.0" />
     <PackageReference Include="MediatR" Version="3.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="1.0.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="1.2.1" />
     <PackageReference Include="Dapper" Version="1.50.2" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0-preview1-25305-02" />
-    <PackageReference Include="Polly" Version="5.2.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="Polly" Version="5.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/Ordering/Ordering.Domain/Ordering.Domain.csproj
+++ b/src/Services/Ordering/Ordering.Domain/Ordering.Domain.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Ordering.Domain</AssemblyName>
-    <NetStandardImplicitPackageVersion>2.0.0-preview1-25301-01</NetStandardImplicitPackageVersion>
     <PackageId>Ordering.Domain</PackageId>
     <AssetTargetFallback>$(AssetTargetFallback);dnxcore50;</AssetTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -13,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="3.0.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Services/Payment/Payment.API/Dockerfile.nanowin
+++ b/src/Services/Payment/Payment.API/Dockerfile.nanowin
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:1.1-runtime-nanoserver
+FROM microsoft/dotnet:2.0-runtime-nanoserver
 SHELL ["powershell"]
 ARG source
 WORKDIR /app
 RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord
 EXPOSE 80
 COPY ${source:-obj/Docker/publish} .
-ENTRYPOINT ["dotnet", "Basket.API.dll"]
+ENTRYPOINT ["dotnet", "Payment.API.dll"]

--- a/src/Services/Payment/Payment.API/Payment.API.csproj
+++ b/src/Services/Payment/Payment.API/Payment.API.csproj
@@ -7,17 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.0-beta6" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="1.0.0" />

--- a/src/Web/WebMVC/Dockerfile.nanowin
+++ b/src/Web/WebMVC/Dockerfile.nanowin
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1-runtime-nanoserver
+FROM microsoft/dotnet:2.0-runtime-nanoserver
 SHELL ["powershell"]
 ARG source
 WORKDIR /app

--- a/src/Web/WebMVC/WebMVC.csproj
+++ b/src/Web/WebMVC/WebMVC.csproj
@@ -66,8 +66,8 @@
 
   <ItemGroup>
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.4.337" />
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.0-msbuild3-final" />
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0-msbuild3-final" />
+    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Web/WebSPA/AppSettings.cs
+++ b/src/Web/WebSPA/AppSettings.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace eShopOnContainers.WebSPA
+﻿namespace eShopOnContainers.WebSPA
 {
     public class AppSettings
     {
@@ -14,6 +9,6 @@ namespace eShopOnContainers.WebSPA
         public string BasketUrl { get; set; }
         public string MarketingUrl { get; set; }
         public string ActivateCampaignDetailFunction { get; set; }
-	public bool UseCustomizationData { get; set; }
+        public bool UseCustomizationData { get; set; }
     }
 }

--- a/src/Web/WebSPA/Dockerfile.nanowin
+++ b/src/Web/WebSPA/Dockerfile.nanowin
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1-runtime-nanoserver
+FROM microsoft/dotnet:2.0-runtime-nanoserver
 SHELL ["powershell"]
 ARG source
 WORKDIR /app

--- a/src/Web/WebStatus/Controllers/HomeController.cs
+++ b/src/Web/WebStatus/Controllers/HomeController.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.HealthChecks;
+using System.Threading.Tasks;
 using WebStatus.Viewmodels;
 
 namespace WebStatus.Controllers

--- a/src/Web/WebStatus/Dockerfile.nanowin
+++ b/src/Web/WebStatus/Dockerfile.nanowin
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:1.1-runtime-nanoserver
+FROM microsoft/dotnet:2.0-runtime-nanoserver
 SHELL ["powershell"]
 ARG source
 WORKDIR /app
 RUN set-itemproperty -path 'HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters' -Name ServerPriorityTimeLimit -Value 0 -Type DWord
 EXPOSE 80
 COPY ${source:-obj/Docker/publish} .
-ENTRYPOINT ["dotnet", "WebMVC.dll"]
+ENTRYPOINT ["dotnet", "WebStatus.dll"]

--- a/src/Web/WebStatus/Extensions/HealthCheckBuilderExtensions.cs
+++ b/src/Web/WebStatus/Extensions/HealthCheckBuilderExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.Extensions.HealthChecks;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace WebStatus.Extensions
 {

--- a/src/Web/WebStatus/Startup.cs
+++ b/src/Web/WebStatus/Startup.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System;
 using WebStatus.Extensions;
 
 namespace WebStatus

--- a/src/Web/WebStatus/Viewmodels/HealthStatusViewModel.cs
+++ b/src/Web/WebStatus/Viewmodels/HealthStatusViewModel.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Extensions.HealthChecks;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace WebStatus.Viewmodels
 {

--- a/src/Web/WebStatus/Viewmodels/NamedCheckResult.cs
+++ b/src/Web/WebStatus/Viewmodels/NamedCheckResult.cs
@@ -1,8 +1,4 @@
 ﻿using Microsoft.Extensions.HealthChecks;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace WebStatus.Viewmodels
 {

--- a/src/Web/WebStatus/WebStatus.csproj
+++ b/src/Web/WebStatus/WebStatus.csproj
@@ -5,7 +5,17 @@
     <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader" Version="14.1.0" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />

--- a/test/Services/FunctionalTests/FunctionalTests.csproj
+++ b/test/Services/FunctionalTests/FunctionalTests.csproj
@@ -46,8 +46,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/test/Services/IntegrationTests/IntegrationTests.csproj
+++ b/test/Services/IntegrationTests/IntegrationTests.csproj
@@ -45,10 +45,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>

--- a/test/Services/UnitTest/Ordering/Domain/OrderAggregateTest.cs
+++ b/test/Services/UnitTest/Ordering/Domain/OrderAggregateTest.cs
@@ -111,7 +111,7 @@ public class OrderAggregateTest
     public void Add_new_Order_raises_new_event()
     {
         //Arrange
-        var userId = new Guid();
+        //var userId = new Guid();
         var street = "fakeStreet";
         var city = "FakeCity";
         var state = "fakeState";
@@ -135,7 +135,7 @@ public class OrderAggregateTest
     public void Add_event_Order_explicitly_raises_new_event()
     {
         //Arrange   
-        var userId = new Guid();
+        //var userId = new Guid();
         var street = "fakeStreet";
         var city = "FakeCity";
         var state = "fakeState";
@@ -159,7 +159,7 @@ public class OrderAggregateTest
     public void Remove_event_Order_explicitly()
     {
         //Arrange    
-        var userId = new Guid();
+        //var userId = new Guid();
         var street = "fakeStreet";
         var city = "FakeCity";
         var state = "fakeState";

--- a/test/Services/UnitTest/UnitTest.csproj
+++ b/test/Services/UnitTest/UnitTest.csproj
@@ -21,12 +21,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="MediatR" Version="3.0.1" />
-    <PackageReference Include="Moq" Version="4.7.10" />
+    <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
https://github.com/aspnet/EntityFrameworkCore/issues/8923#issuecomment-310431600

https://github.com/aspnet/EntityFrameworkCore/issues/9129

https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/4bc89022f1e1e0d314a0dda57db829e51b4963df/ChangeLog.md autoack
https://www.nuget.org/packages/FluentValidation.Mvc6/ mvc 6 must be changed to FluentValidation.AspNetCore
https://github.com/aspnet/Security/issues/1310 auth in moq changed