### PR TITLE
Fix/1403and1404 removed duplicate Key SubscriptionClientName and added app.UseAuthorization() call

### DIFF
--- a/src/Tests/Services/Application.FunctionalTests/Services/Basket/BasketTestsStartup.cs
+++ b/src/Tests/Services/Application.FunctionalTests/Services/Basket/BasketTestsStartup.cs
@@ -16,6 +16,7 @@ namespace FunctionalTests.Services.Basket
             if (Configuration["isTest"] == bool.TrueString.ToLowerInvariant())
             {
                 app.UseMiddleware<AutoAuthorizeMiddleware>();
+                app.UseAuthorization();
             }
             else
             {

--- a/src/Tests/Services/Application.FunctionalTests/Services/Location/LocationsTestsStartup.cs
+++ b/src/Tests/Services/Application.FunctionalTests/Services/Location/LocationsTestsStartup.cs
@@ -19,6 +19,7 @@
             if (Configuration["isTest"] == bool.TrueString.ToLowerInvariant())
             {
                 app.UseMiddleware<LocationAuthorizeMiddleware>();
+                app.UseAuthorization();
             }
             else
             {

--- a/src/Tests/Services/Application.FunctionalTests/Services/Marketing/MarketingTestsStartup.cs
+++ b/src/Tests/Services/Application.FunctionalTests/Services/Marketing/MarketingTestsStartup.cs
@@ -16,6 +16,7 @@
             if (Configuration["isTest"] == bool.TrueString.ToLowerInvariant())
             {
                 app.UseMiddleware<AutoAuthorizeMiddleware>();
+                app.UseAuthorization();
             }
             else
             {

--- a/src/Tests/Services/Application.FunctionalTests/Services/Marketing/appsettings.json
+++ b/src/Tests/Services/Application.FunctionalTests/Services/Marketing/appsettings.json
@@ -1,12 +1,11 @@
 ﻿{
+  "AzureServiceBusEnabled": false,
   "ConnectionString": "Server=tcp:127.0.0.1,5433;Initial Catalog=Microsoft.eShopOnContainers.Services.MarketingDb;User Id=sa;Password=Pass@word",
-  "MongoConnectionString": "mongodb://localhost:27017",
-  "MongoDatabase": "MarketingDb",
+  "EventBusConnection": "localhost",
   "IdentityUrl": "http://localhost:5105",
   "isTest": "true",
-  "EventBusConnection": "localhost",
-  "AzureServiceBusEnabled": false,
-  "SubscriptionClientName": "Marketing",
+  "MongoConnectionString": "mongodb://localhost:27017",
+  "MongoDatabase": "MarketingDb",
   "PicBaseUrl": "http://localhost:5110/api/v1/campaigns/[0]/pic/",
   "SubscriptionClientName": "Marketing"
 }


### PR DESCRIPTION
To make the unit tests IntegrationEventsScenarios.Post_update_product_price_and_catalog_and_basket_list_modified and MarketingScenarios.Set_new_user_location_and_get_location_campaign_by_user_id pass, handled the follwing issues:

Removed duplicate key SubscriptionClientName from Tests/Services/Application.FunctionalTests/Services/Marketing/appsettings.json and sorted its content in asc order (see #1403)

Added app.UseAuthorization() call to BasketTestsStartup, LocationsTestsStartup, and MarketingTestsStartup to fix failed unit tests IntegrationEventsScenarios.Post_update_product_price_and_catalog_and_basket_list_modified and MarketingScenarios.Set_new_user_location_and_get_location_campaign_by_user_id (see #1404)