### PR TITLE
#1407: Fixed issues to make Unit Test pass

### DIFF
--- a/src/Services/Ordering/Ordering.API/Application/ModelDTOs/OrderDTO.cs
+++ b/src/Services/Ordering/Ordering.API/Application/ModelDTOs/OrderDTO.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Ordering.API.Application.ModelDTOs
+{
+    public class OrderDTO
+    {
+        public int OrderNumber { get; set; }
+
+        public OrderDTO()
+        {
+            // Intenetionally left blank
+        }
+
+        public OrderDTO(int orderNumber)
+        {
+            OrderNumber = orderNumber;
+        }
+    }
+}

--- a/src/Services/Ordering/Ordering.API/Controllers/OrdersController.cs
+++ b/src/Services/Ordering/Ordering.API/Controllers/OrdersController.cs
@@ -6,8 +6,8 @@ using Microsoft.eShopOnContainers.Services.Ordering.API.Application.Commands;
 using Microsoft.eShopOnContainers.Services.Ordering.API.Application.Queries;
 using Microsoft.eShopOnContainers.Services.Ordering.API.Infrastructure.Services;
 using Microsoft.Extensions.Logging;
-using Ordering.API.Application.Behaviors;
 using Ordering.API.Application.Commands;
+using Ordering.API.Application.ModelDTOs;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -41,9 +41,11 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.API.Controllers
         [HttpPut]
         [ProducesResponseType((int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-        public async Task<IActionResult> CancelOrderAsync([FromBody]CancelOrderCommand command, [FromHeader(Name = "x-requestid")] string requestId)
+        public async Task<IActionResult> CancelOrderAsync([FromBody]OrderDTO orderDto, [FromHeader(Name = "x-requestid")] string requestId)
         {
             bool commandResult = false;
+
+            CancelOrderCommand command = new CancelOrderCommand(orderDto.OrderNumber);
 
             if (Guid.TryParse(requestId, out Guid guid) && guid != Guid.Empty)
             {

--- a/src/Services/Ordering/Ordering.UnitTests/Application/OrdersWebApiTest.cs
+++ b/src/Services/Ordering/Ordering.UnitTests/Application/OrdersWebApiTest.cs
@@ -7,6 +7,7 @@ using Microsoft.eShopOnContainers.Services.Ordering.API.Infrastructure.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Ordering.API.Application.Commands;
+using Ordering.API.Application.ModelDTOs;
 using System;
 using System.Linq;
 using System.Threading;
@@ -39,7 +40,7 @@ namespace UnitTest.Ordering.Application
 
             //Act
             var orderController = new OrdersController(_mediatorMock.Object, _orderQueriesMock.Object, _identityServiceMock.Object, _loggerMock.Object);
-            var actionResult = await orderController.CancelOrderAsync(new CancelOrderCommand(1), Guid.NewGuid().ToString()) as OkResult;
+            var actionResult = await orderController.CancelOrderAsync(new OrderDTO(1), Guid.NewGuid().ToString()) as OkResult;
 
             //Assert
             Assert.Equal(actionResult.StatusCode, (int)System.Net.HttpStatusCode.OK);
@@ -55,7 +56,7 @@ namespace UnitTest.Ordering.Application
 
             //Act
             var orderController = new OrdersController(_mediatorMock.Object, _orderQueriesMock.Object, _identityServiceMock.Object, _loggerMock.Object);
-            var actionResult = await orderController.CancelOrderAsync(new CancelOrderCommand(1), String.Empty) as BadRequestResult;
+            var actionResult = await orderController.CancelOrderAsync(new OrderDTO(1), String.Empty) as BadRequestResult;
 
             //Assert
             Assert.Equal(actionResult.StatusCode, (int)System.Net.HttpStatusCode.BadRequest);

--- a/src/Tests/Services/Application.FunctionalTests/Middleware/AutoAuthorizeMiddleware.cs
+++ b/src/Tests/Services/Application.FunctionalTests/Middleware/AutoAuthorizeMiddleware.cs
@@ -25,6 +25,7 @@ namespace FunctionalTests.Middleware
 
             identity.AddClaim(new Claim("sub", IDENTITY_ID));
             identity.AddClaim(new Claim("unique_name", IDENTITY_ID));
+            identity.AddClaim(new Claim(ClaimTypes.Name, IDENTITY_ID));
 
             httpContext.User.AddIdentity(identity);
             await _next.Invoke(httpContext);

--- a/src/Tests/Services/Application.FunctionalTests/Services/Basket/BasketTestsStartup.cs
+++ b/src/Tests/Services/Application.FunctionalTests/Services/Basket/BasketTestsStartup.cs
@@ -16,6 +16,7 @@ namespace FunctionalTests.Services.Basket
             if (Configuration["isTest"] == bool.TrueString.ToLowerInvariant())
             {
                 app.UseMiddleware<AutoAuthorizeMiddleware>();
+                app.UseAuthorization();
             }
             else
             {

--- a/src/Tests/Services/Application.FunctionalTests/Services/Ordering/OrderingScenarios.cs
+++ b/src/Tests/Services/Application.FunctionalTests/Services/Ordering/OrderingScenarios.cs
@@ -79,7 +79,6 @@ namespace FunctionalTests.Services.Ordering
                 int.TryParse(lastOrder.OrderNumber, out int id);
                 var orderDetails = await orderClient.GetStringAsync(OrderingScenariosBase.Get.OrderBy(id));
                 order = JsonConvert.DeserializeObject<Order>(orderDetails);
-                order.City = city;
 
                 if (IsOrderCreated(order, city))
                 {

--- a/src/Tests/Services/Application.FunctionalTests/Services/Ordering/OrderingTestsStartup.cs
+++ b/src/Tests/Services/Application.FunctionalTests/Services/Ordering/OrderingTestsStartup.cs
@@ -20,6 +20,7 @@ namespace FunctionalTests.Services.Ordering
             if (Configuration["isTest"] == bool.TrueString.ToLowerInvariant())
             {
                 app.UseMiddleware<AutoAuthorizeMiddleware>();
+                app.UseAuthorization();
             }
             else
             {

--- a/src/Tests/Services/Application.FunctionalTests/Services/Ordering/appsettings.json
+++ b/src/Tests/Services/Application.FunctionalTests/Services/Ordering/appsettings.json
@@ -2,6 +2,7 @@
   "ConnectionString": "Server=tcp:127.0.0.1,5433;Database=Microsoft.eShopOnContainers.Services.OrderingDb;User Id=sa;Password=Pass@word;",
   "ExternalCatalogBaseUrl": "http://localhost:5101",
   "IdentityUrl": "http://localhost:5105",
+  "IdentityUrlExternal": "http://localhost:5105",
   "isTest": "true",
   "EventBusConnection": "localhost",
   "CheckUpdateTime": "30000",


### PR DESCRIPTION
Fixed Unit Test: `OrderingScenarios.Cancel_basket_and_check_order_status_cancelled`

for details, see #1407
contains also a fix to `FunctionalTests.Services.Basket.BasketTestsStartup.ConfigureAuth`, described by #1404 , as these changes were not merged when implementing this fix.