### PR TITLE
Allows the event name and class name to be different

### DIFF
--- a/src/BuildingBlocks/EventBus/EventBus/Events/IntegrationEventNameAttribute.cs
+++ b/src/BuildingBlocks/EventBus/EventBus/Events/IntegrationEventNameAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Events
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class IntegrationEventNameAttribute : Attribute
+    {
+        public string EventName { get; private set; }
+        
+        public IntegrationEventNameAttribute(string eventName)
+        {
+            EventName = eventName;
+        }
+    }
+}

--- a/src/BuildingBlocks/EventBus/EventBus/Extensions/IntegrationEventNameExtensions.cs
+++ b/src/BuildingBlocks/EventBus/EventBus/Extensions/IntegrationEventNameExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Events;
+
+namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Extensions
+{
+    public static class IntegrationEventNameExtensions
+    {
+        public static string GetEventName(this IntegrationEvent @event)
+        {
+            var type = @event.GetType();
+            var attributes = type.GetCustomAttributes(false);
+            foreach (var attr in attributes)
+            {
+                //if class contains IntegrationEventNameAttribute take event name from attribute
+                if (attr is IntegrationEventNameAttribute eventInfoAttribute)
+                    return eventInfoAttribute.EventName;
+            }
+
+            return type.Name; //otherwise event name is class name
+        }
+    }
+}

--- a/src/BuildingBlocks/EventBus/EventBus/InMemoryEventBusSubscriptionsManager.cs
+++ b/src/BuildingBlocks/EventBus/EventBus/InMemoryEventBusSubscriptionsManager.cs
@@ -156,7 +156,16 @@ namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBus
 
         public string GetEventKey<T>()
         {
-            return typeof(T).Name;
+            var type = typeof(T);
+            var attributes = type.GetCustomAttributes(false);
+            foreach (var attr in attributes)
+            {
+                //if class contains IntegrationEventNameAttribute take event name from attribute
+                if (attr is IntegrationEventNameAttribute eventInfoAttribute)
+                    return eventInfoAttribute.EventName;
+            }
+
+            return type.Name; //otherwise event name is class name
         }
     }
 }

--- a/src/BuildingBlocks/EventBus/EventBus/InMemoryEventBusSubscriptionsManager.cs
+++ b/src/BuildingBlocks/EventBus/EventBus/InMemoryEventBusSubscriptionsManager.cs
@@ -11,14 +11,14 @@ namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBus
 
 
         private readonly Dictionary<string, List<SubscriptionInfo>> _handlers;
-        private readonly List<Type> _eventTypes;
+        private readonly Dictionary<string, Type> _eventTypes;
 
         public event EventHandler<string> OnEventRemoved;
 
         public InMemoryEventBusSubscriptionsManager()
         {
             _handlers = new Dictionary<string, List<SubscriptionInfo>>();
-            _eventTypes = new List<Type>();
+            _eventTypes = new Dictionary<string, Type>();
         }
 
         public bool IsEmpty => !_handlers.Keys.Any();
@@ -38,9 +38,9 @@ namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBus
 
             DoAddSubscription(typeof(TH), eventName, isDynamic: false);
 
-            if (!_eventTypes.Contains(typeof(T)))
+            if (!_eventTypes.ContainsKey(eventName))
             {
-                _eventTypes.Add(typeof(T));
+                _eventTypes.Add(eventName, typeof(T));
             }
         }
 
@@ -94,10 +94,9 @@ namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBus
                 if (!_handlers[eventName].Any())
                 {
                     _handlers.Remove(eventName);
-                    var eventType = _eventTypes.SingleOrDefault(e => e.Name == eventName);
-                    if (eventType != null)
+                    if (_eventTypes.ContainsKey(eventName))
                     {
-                        _eventTypes.Remove(eventType);
+                        _eventTypes.Remove(eventName);
                     }
                     RaiseOnEventRemoved(eventName);
                 }
@@ -152,7 +151,7 @@ namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBus
         }
         public bool HasSubscriptionsForEvent(string eventName) => _handlers.ContainsKey(eventName);
 
-        public Type GetEventTypeByName(string eventName) => _eventTypes.SingleOrDefault(t => t.Name == eventName);
+        public Type GetEventTypeByName(string eventName) => _eventTypes.ContainsKey(eventName) ? _eventTypes[eventName] : default;
 
         public string GetEventKey<T>()
         {

--- a/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.cs
+++ b/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.cs
@@ -80,7 +80,7 @@ namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBusRabbitMQ
                     _logger.LogWarning(ex, "Could not publish event: {EventId} after {Timeout}s ({ExceptionMessage})", @event.Id, $"{time.TotalSeconds:n1}", ex.Message);
                 });
 
-            var eventName = @event.GetType().Name;
+            var eventName = @event.GetEventName();
 
             _logger.LogTrace("Creating RabbitMQ channel to publish event: {EventId} ({EventName})", @event.Id, eventName);
 

--- a/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.cs
+++ b/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBusServiceBus
+﻿using Microsoft.eShopOnContainers.BuildingBlocks.EventBus.Extensions;
+
+namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBusServiceBus
 {
     using Autofac;
     using Microsoft.Azure.ServiceBus;
@@ -40,7 +42,7 @@
 
         public void Publish(IntegrationEvent @event)
         {
-            var eventName = @event.GetType().Name.Replace(INTEGRATION_EVENT_SUFFIX, "");
+            var eventName = @event.GetEventName().Replace(INTEGRATION_EVENT_SUFFIX, "");
             var jsonMessage = JsonConvert.SerializeObject(@event);
             var body = Encoding.UTF8.GetBytes(jsonMessage);
 
@@ -70,7 +72,7 @@
             where T : IntegrationEvent
             where TH : IIntegrationEventHandler<T>
         {
-            var eventName = typeof(T).Name.Replace(INTEGRATION_EVENT_SUFFIX, "");
+            var eventName = _subsManager.GetEventKey<T>().Replace(INTEGRATION_EVENT_SUFFIX, "");
 
             var containsKey = _subsManager.HasSubscriptionsForEvent<T>();
             if (!containsKey)
@@ -98,7 +100,7 @@
             where T : IntegrationEvent
             where TH : IIntegrationEventHandler<T>
         {
-            var eventName = typeof(T).Name.Replace(INTEGRATION_EVENT_SUFFIX, "");
+            var eventName = _subsManager.GetEventKey<T>().Replace(INTEGRATION_EVENT_SUFFIX, "");
 
             try
             {


### PR DESCRIPTION
Implements `IntegrationEventNameAttribute` that allows the event name and class name to be different.

For example:
```csharp
[IntegrationEventName("MyIntegrationEvent")]//you can change the name of the event
public class MyEvent : IntegrationEvent
{        
	///
}
```

May be required in cases where the event name conflicts with a class name in your project.