### PR TITLE
updated CardType and Enumeration classes

### DIFF
--- a/src/Services/Ordering/Ordering.Domain/AggregatesModel/BuyerAggregate/CardType.cs
+++ b/src/Services/Ordering/Ordering.Domain/AggregatesModel/BuyerAggregate/CardType.cs
@@ -9,9 +9,9 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.B
     public class CardType
         : Enumeration
     {
-        public static CardType Amex = new CardType(1, "Amex");
-        public static CardType Visa = new CardType(2, "Visa");
-        public static CardType MasterCard = new CardType(3, "MasterCard");
+        public static CardType Amex = new CardType(1, nameof(Amex));
+        public static CardType Visa = new CardType(2, nameof(Visa));
+        public static CardType MasterCard = new CardType(3, nameof(MasterCard));
 
         public CardType(int id, string name)
             : base(id, name)

--- a/src/Services/Ordering/Ordering.Domain/SeedWork/Enumeration.cs
+++ b/src/Services/Ordering/Ordering.Domain/SeedWork/Enumeration.cs
@@ -24,7 +24,7 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
         
         public override bool Equals(object obj)
         {
-            if (!(obj is Enumeration otherValue))
+            if (obj is not Enumeration otherValue)
             {
                 return false;
             }

--- a/src/Services/Ordering/Ordering.Domain/SeedWork/Enumeration.cs
+++ b/src/Services/Ordering/Ordering.Domain/SeedWork/Enumeration.cs
@@ -11,27 +11,22 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
 
         public int Id { get; private set; }
 
-        protected Enumeration(int id, string name)
-        {
-            Id = id;
-            Name = name;
-        }
+        protected Enumeration(int id, string name) => (Id, Name) = (id, name);
 
         public override string ToString() => Name;
-
-        public static IEnumerable<T> GetAll<T>() where T : Enumeration
-        {
-            var fields = typeof(T).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
-
-            return fields.Select(f => f.GetValue(null)).Cast<T>();
-        }
-
+        
+        public static IEnumerable<T> GetAll<T>() where T : Enumeration =>
+            typeof(T).GetFields(BindingFlags.Public |
+                                BindingFlags.Static |
+                                BindingFlags.DeclaredOnly)
+                     .Select(f => f.GetValue(null)).Cast<T>();
+        
         public override bool Equals(object obj)
         {
-            var otherValue = obj as Enumeration;
-
-            if (otherValue == null)
+            if (!(obj is Enumeration otherValue))
+            {
                 return false;
+            }
 
             var typeMatches = GetType().Equals(obj.GetType());
             var valueMatches = Id.Equals(otherValue.Id);

--- a/src/Services/Ordering/Ordering.Domain/SeedWork/Enumeration.cs
+++ b/src/Services/Ordering/Ordering.Domain/SeedWork/Enumeration.cs
@@ -19,7 +19,8 @@ namespace Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork
             typeof(T).GetFields(BindingFlags.Public |
                                 BindingFlags.Static |
                                 BindingFlags.DeclaredOnly)
-                     .Select(f => f.GetValue(null)).Cast<T>();
+                     .Select(f => f.GetValue(null))
+                     .Cast<T>();
         
         public override bool Equals(object obj)
         {


### PR DESCRIPTION
PR for issue #1527 

Updating the `Microsoft.eShopOnContainers.Services.Ordering.Domain.SeedWork.Enumeration` class the and `Microsoft.eShopOnContainers.Services.Ordering.Domain.AggregatesModel.BuyerAggregate.CardType` class to use modern C# features:

- use nameof expression
- use pattern matching
- use expression bodied members consistently

A corresponding [pull request](https://github.com/dotnet/docs/pull/21677) for the Microsoft documentation is also pending; changes here are per suggestion by @sughosneo.
