### PR TITLE
fix(#1261): remove helm chart indent for config map glob

### DIFF
--- a/deploy/k8s/helm/apigwmm/templates/envoy-cm.yaml
+++ b/deploy/k8s/helm/apigwmm/templates/envoy-cm.yaml
@@ -10,5 +10,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{ (.Files.Glob "envoy.yaml").AsConfig  | indent 2 }}
+{{ (.Files.Glob "envoy.yaml").AsConfig  | indent 2 }}
 

--- a/deploy/k8s/helm/apigwms/templates/envoy-cm.yaml
+++ b/deploy/k8s/helm/apigwms/templates/envoy-cm.yaml
@@ -10,5 +10,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{ (.Files.Glob "envoy.yaml").AsConfig | indent 2 }}
+{{ (.Files.Glob "envoy.yaml").AsConfig | indent 2 }}
 

--- a/deploy/k8s/helm/apigwwm/templates/envoy-cm.yaml
+++ b/deploy/k8s/helm/apigwwm/templates/envoy-cm.yaml
@@ -10,5 +10,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{ (.Files.Glob "envoy.yaml").AsConfig | indent 2 -}} 
+{{ (.Files.Glob "envoy.yaml").AsConfig | indent 2 -}} 
 

--- a/deploy/k8s/helm/apigwws/templates/envoy-cm.yaml
+++ b/deploy/k8s/helm/apigwws/templates/envoy-cm.yaml
@@ -10,5 +10,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{ (.Files.Glob "envoy.yaml").AsConfig | indent 2 }}
+{{ (.Files.Glob "envoy.yaml").AsConfig | indent 2 }}
 


### PR DESCRIPTION
Closes #1261 

Let me know if any other changes are necessary. I have not explicitly tested the changes to the `apigwmm` and `apigwwm`