### PR TITLE
Fix WebSPA catalog pager display

### DIFF
--- a/src/Web/WebSPA/Client/modules/catalog/catalog.component.ts
+++ b/src/Web/WebSPA/Client/modules/catalog/catalog.component.ts
@@ -95,7 +95,7 @@ export class CatalogComponent implements OnInit {
                     itemsPage : catalog.pageSize,
                     totalItems : catalog.count,
                     totalPages: Math.ceil(catalog.count / catalog.pageSize),
-                    items: catalog.pageSize
+                    items: catalog.data.length
                 };
         });
     }

--- a/src/Web/WebSPA/Client/modules/shared/components/pager/pager.ts
+++ b/src/Web/WebSPA/Client/modules/shared/components/pager/pager.ts
@@ -25,8 +25,6 @@ export class Pager implements OnInit, OnChanges  {
 
     ngOnChanges() {
         if (this.model) {
-            this.model.items = (this.model.itemsPage > this.model.totalItems) ? this.model.totalItems : this.model.itemsPage;
-
             this.buttonStates.previousDisabled = (this.model.actualPage == 0);
             this.buttonStates.nextDisabled = (this.model.actualPage + 1 >= this.model.totalPages);
         }


### PR DESCRIPTION
Hi,

in both WebMVC and WebSPA the catalog pager initially displays:

"Showing 10 of 13 products - Page 1 - 2"

which is correct, 10 products are shown.
However, after clicking "Next":

WebMVC: "Showing 3 of 13 products - Page 2 - 2"
WebSPA: "Showing 10 of 13 products - Page 2 - 2"

The WebSPA pager is incorrect, only 3 products are shown.

This PR aims to fix it.