### PR TITLE
Fix WebSPA catalog filter

### DIFF
--- a/src/Web/WebSPA/Client/modules/catalog/catalog.component.ts
+++ b/src/Web/WebSPA/Client/modules/catalog/catalog.component.ts
@@ -59,6 +59,7 @@ export class CatalogComponent implements OnInit {
         
         this.brandSelected = this.brandSelected && this.brandSelected.toString() != "null" ? this.brandSelected : null;
         this.typeSelected = this.typeSelected && this.typeSelected.toString() != "null" ? this.typeSelected : null;
+        this.paginationInfo.actualPage = 0;
         this.getCatalog(this.paginationInfo.itemsPage, this.paginationInfo.actualPage, this.brandSelected, this.typeSelected);
     }
 


### PR DESCRIPTION
Hi,

if in the catalog you
1. click "Next"
2. select ".NET" from the "Brand" drop-down
3. click ">" to filter the products

WebMVC and WebSPA show different results:

WebMVC: "Showing 6 of 6 products - Page 1 - 1" (goes back to first page)
WebSPA: "THERE ARE NO RESULTS THAT MATCH YOUR SEARCH" (stays on second page)

Assuming WebMVC's behavior is the desired one, this PR changes WebSPA to do the same.