### PR TITLE
Instrumenting services with OpenTelemetry

### DIFF
--- a/src/OpenTelemetry/otel-collector-config.yaml
+++ b/src/OpenTelemetry/otel-collector-config.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  logging:
+    loglevel: debug
+
+processors:
+  batch:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]

--- a/src/Services/Basket/Basket.API/Basket.API.csproj
+++ b/src/Services/Basket/Basket.API/Basket.API.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="OpenTelemetry" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc2" />

--- a/src/Services/Basket/Basket.API/Basket.API.csproj
+++ b/src/Services/Basket/Basket.API/Basket.API.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" />

--- a/src/Services/Basket/Basket.API/Basket.API.csproj
+++ b/src/Services/Basket/Basket.API/Basket.API.csproj
@@ -43,6 +43,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Protobuf Include="Proto\basket.proto" GrpcServices="Server" Generator="MSBuild:Compile" />
     <Content Include="@(Protobuf)" />
     <None Remove="@(Protobuf)" />

--- a/src/Services/Basket/Basket.API/OpenTelemetry.cs
+++ b/src/Services/Basket/Basket.API/OpenTelemetry.cs
@@ -43,6 +43,13 @@ static class OpenTelemetryExtensions
                     options.Headers = headers;
                 });
                 break;
+            case "zipkin":
+                tracerProviderBuilder.AddZipkinExporter(options =>
+                {
+                    var endpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_ZIPKIN_ENDPOINT");
+                    options.Endpoint = new Uri(endpoint);
+                });
+                break;
             default:
                 tracerProviderBuilder.AddConsoleExporter();
                 break;

--- a/src/Services/Basket/Basket.API/OpenTelemetry.cs
+++ b/src/Services/Basket/Basket.API/OpenTelemetry.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using StackExchange.Redis;
+using System;
+
+static class OpenTelemetryExtensions
+{
+    public static void AddOpenTelemetry(ConnectionMultiplexer connectionMultiplexer)
+    {
+        if (connectionMultiplexer == null) throw new ArgumentException("!!!!conn is null!");
+        var exportType = Environment.GetEnvironmentVariable("OTEL_USE_EXPORTER")?.ToLower();
+        if (exportType == null)
+        {
+            return;
+        }
+
+        var tracerProviderBuilder = Sdk.CreateTracerProviderBuilder();
+
+        // Configure resource
+        tracerProviderBuilder
+            .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("Basket.API"));
+
+        // Configure instrumentation
+        tracerProviderBuilder
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddRedisInstrumentation(connectionMultiplexer);
+
+        // Configure exporter
+        switch (exportType)
+        {
+            case "otlp":
+                tracerProviderBuilder.AddOtlpExporter(options =>
+                {
+                    var endpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+                        ?? Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT");
+                    options.Endpoint = new Uri(endpoint);
+
+                    var headers = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_TRACES_HEADERS")
+                        ?? Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_HEADERS");
+                    options.Headers = headers;
+                });
+                break;
+            default:
+                tracerProviderBuilder.AddConsoleExporter();
+                break;
+        }
+
+        tracerProviderBuilder.Build();
+    }
+}

--- a/src/Services/Basket/Basket.API/OpenTelemetry.cs
+++ b/src/Services/Basket/Basket.API/OpenTelemetry.cs
@@ -9,7 +9,6 @@ static class OpenTelemetryExtensions
 {
     public static void AddOpenTelemetry(ConnectionMultiplexer connectionMultiplexer)
     {
-        if (connectionMultiplexer == null) throw new ArgumentException("!!!!conn is null!");
         var exportType = Environment.GetEnvironmentVariable("OTEL_USE_EXPORTER")?.ToLower();
         if (exportType == null)
         {

--- a/src/Services/Basket/Basket.API/OpenTelemetry.cs
+++ b/src/Services/Basket/Basket.API/OpenTelemetry.cs
@@ -31,6 +31,13 @@ static class OpenTelemetryExtensions
         // Configure exporter
         switch (exportType)
         {
+            case "jaeger":
+                tracerProviderBuilder.AddJaegerExporter(options =>
+                {
+                    var agentHost = Environment.GetEnvironmentVariable("OTEL_EXPORTER_JAEGER_AGENTHOST");
+                    options.AgentHost = agentHost;
+                });
+                break;
             case "otlp":
                 tracerProviderBuilder.AddOtlpExporter(options =>
                 {

--- a/src/Services/Basket/Basket.API/Startup.cs
+++ b/src/Services/Basket/Basket.API/Startup.cs
@@ -185,8 +185,9 @@ namespace Microsoft.eShopOnContainers.Services.Basket.API
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory, ConnectionMultiplexer connectionMultiplexer)
         {
+            OpenTelemetryExtensions.AddOpenTelemetry(connectionMultiplexer);
             //loggerFactory.AddAzureWebAppDiagnostics();
             //loggerFactory.AddApplicationInsights(app.ApplicationServices, LogLevel.Trace);
 

--- a/src/Web/WebMVC/OpenTelemetry.cs
+++ b/src/Web/WebMVC/OpenTelemetry.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using System;
+
+static class OpenTelemetryExtensions
+{
+    public static IServiceCollection AddOpenTelemetry(this IServiceCollection services)
+    {
+        var exportType = Environment.GetEnvironmentVariable("OTEL_USE_EXPORTER")?.ToLower();
+        if (exportType == null)
+        {
+            return services;
+        }
+
+        return services.AddOpenTelemetryTracing((serviceProvider, tracerProviderBuilder) =>
+        {
+            // Configure resource
+            tracerProviderBuilder
+                .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("WebMVC"));
+
+            // Configure instrumentation
+            tracerProviderBuilder
+                .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation();
+
+            // Configure exporter
+            switch (exportType)
+            {
+                case "otlp":
+                    tracerProviderBuilder.AddOtlpExporter(options =>
+                    {
+                        var endpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+                            ?? Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT");
+                        options.Endpoint = new Uri(endpoint);
+
+                        var headers = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_TRACES_HEADERS")
+                            ?? Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_HEADERS");
+                        options.Headers = headers;
+                    });
+                    break;
+                default:
+                    tracerProviderBuilder.AddConsoleExporter();
+                    break;
+            }
+        });
+    }
+}

--- a/src/Web/WebMVC/OpenTelemetry.cs
+++ b/src/Web/WebMVC/OpenTelemetry.cs
@@ -39,6 +39,13 @@ static class OpenTelemetryExtensions
                         options.Headers = headers;
                     });
                     break;
+                case "zipkin":
+                    tracerProviderBuilder.AddZipkinExporter(options =>
+                    {
+                        var endpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_ZIPKIN_ENDPOINT");
+                        options.Endpoint = new Uri(endpoint);
+                    });
+                    break;
                 default:
                     tracerProviderBuilder.AddConsoleExporter();
                     break;

--- a/src/Web/WebMVC/OpenTelemetry.cs
+++ b/src/Web/WebMVC/OpenTelemetry.cs
@@ -27,6 +27,13 @@ static class OpenTelemetryExtensions
             // Configure exporter
             switch (exportType)
             {
+                case "jaeger":
+                    tracerProviderBuilder.AddJaegerExporter(options =>
+                    {
+                        var agentHost = Environment.GetEnvironmentVariable("OTEL_EXPORTER_JAEGER_AGENTHOST");
+                        options.AgentHost = agentHost;
+                    });
+                    break;
                 case "otlp":
                     tracerProviderBuilder.AddOtlpExporter(options =>
                     {

--- a/src/Web/WebMVC/Startup.cs
+++ b/src/Web/WebMVC/Startup.cs
@@ -36,6 +36,7 @@ namespace Microsoft.eShopOnContainers.WebMVC
             services.AddControllersWithViews()
                 .Services
                 .AddAppInsight(Configuration)
+                .AddOpenTelemetry()
                 .AddHealthChecks(Configuration)
                 .AddCustomMvc(Configuration)
                 .AddDevspaces()

--- a/src/Web/WebMVC/WebMVC.csproj
+++ b/src/Web/WebMVC/WebMVC.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" />

--- a/src/Web/WebMVC/WebMVC.csproj
+++ b/src/Web/WebMVC/WebMVC.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="OpenTelemetry" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc2" />

--- a/src/Web/WebMVC/WebMVC.csproj
+++ b/src/Web/WebMVC/WebMVC.csproj
@@ -45,6 +45,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="ViewModels\CampaignItem.cs" />
   </ItemGroup>
 

--- a/src/docker-compose.opentelemetry.console.yml
+++ b/src/docker-compose.opentelemetry.console.yml
@@ -6,6 +6,10 @@ version: '3.4'
 # docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.opentelemetry.console.yml up
 
 services:
+  basket-api:
+    environment:
+      - OTEL_USE_EXPORTER=console
+
   webmvc:
     environment:
       - OTEL_USE_EXPORTER=console

--- a/src/docker-compose.opentelemetry.console.yml
+++ b/src/docker-compose.opentelemetry.console.yml
@@ -1,0 +1,11 @@
+version: '3.4'
+
+# The OpenTelemetry docker-compose file is used to configure OpenTelemetry for the services
+#
+# You need to start it with the following CLI command:
+# docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.opentelemetry.console.yml up
+
+services:
+  webmvc:
+    environment:
+      - OTEL_USE_EXPORTER=console

--- a/src/docker-compose.opentelemetry.jaeger.yml
+++ b/src/docker-compose.opentelemetry.jaeger.yml
@@ -1,0 +1,29 @@
+version: '3.4'
+
+# The OpenTelemetry docker-compose file is used to configure OpenTelemetry for the services
+#
+# You need to start it with the following CLI command:
+# docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.opentelemetry.zipkin.yml up
+
+services:
+  jaeger-all-in-one:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "5775:5775/udp"
+      - "6831:6831/udp"
+      - "6832:6832/udp"
+      - "5778:5778"
+      - "16686:16686"
+      - "14268:14268"
+      - "14250:14250"
+      - "9411:9411"
+
+  basket-api:
+    environment:
+      - OTEL_USE_EXPORTER=jaeger
+      - OTEL_EXPORTER_JAEGER_AGENTHOST=${OTEL_EXPORTER_JAEGER_AGENTHOST:-jaeger-all-in-one}
+
+  webmvc:
+    environment:
+      - OTEL_USE_EXPORTER=jaeger
+      - OTEL_EXPORTER_JAEGER_AGENTHOST=${OTEL_EXPORTER_JAEGER_AGENTHOST:-jaeger-all-in-one}

--- a/src/docker-compose.opentelemetry.otlp.yml
+++ b/src/docker-compose.opentelemetry.otlp.yml
@@ -1,0 +1,21 @@
+version: '3.4'
+
+# The OpenTelemetry docker-compose file is used to configure OpenTelemetry for the services
+#
+# You need to start it with the following CLI command:
+# docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.opentelemetry.otlp.yml up
+
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./OpenTelemetry/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317"        # OTLP gRPC receiver
+
+  webmvc:
+    environment:
+      - OTEL_USE_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-http://otel-collector:4317}
+      - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS}

--- a/src/docker-compose.opentelemetry.otlp.yml
+++ b/src/docker-compose.opentelemetry.otlp.yml
@@ -14,6 +14,12 @@ services:
     ports:
       - "4317"        # OTLP gRPC receiver
 
+  basket-api:
+    environment:
+      - OTEL_USE_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-http://otel-collector:4317}
+      - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS}
+
   webmvc:
     environment:
       - OTEL_USE_EXPORTER=otlp

--- a/src/docker-compose.opentelemetry.zipkin.yml
+++ b/src/docker-compose.opentelemetry.zipkin.yml
@@ -1,0 +1,22 @@
+version: '3.4'
+
+# The OpenTelemetry docker-compose file is used to configure OpenTelemetry for the services
+#
+# You need to start it with the following CLI command:
+# docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.opentelemetry.zipkin.yml up
+
+services:
+  zipkin:
+    image: openzipkin/zipkin:latest
+    ports:
+      - "9411:9411"
+
+  basket-api:
+    environment:
+      - OTEL_USE_EXPORTER=zipkin
+      - OTEL_EXPORTER_ZIPKIN_ENDPOINT=${OTEL_EXPORTER_ZIPKIN_ENDPOINT:-http://zipkin:9411/api/v2/spans}
+
+  webmvc:
+    environment:
+      - OTEL_USE_EXPORTER=zipkin
+      - OTEL_EXPORTER_ZIPKIN_ENDPOINT=${OTEL_EXPORTER_ZIPKIN_ENDPOINT:-http://zipkin:9411/api/v2/spans}


### PR DESCRIPTION
Submitting this PR to start a discussion about instrumenting eShopOnContainers with [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet).

I've instrumented two eShopOnContainer services: WebMVC and Basket.API.

Both services configure a tracer with ASP.NET Core and HttpClient instrumentation. Additionally, Redis instrumentation is configured for the Basket.API.

Depending on how eShopOnContainers is spun up, I've set things up so that OpenTelemetry data can be exported to a variety of backends - this includes to Jaeger, Zipkin, OTLP collector, or directly to the console.

### Run in one of the following ways

#### Jaeger
```shell 
docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.opentelemetry.jaeger.yml up
```

Go to http://localhost:16686 to view trace data with the Jaeger UI.

#### Zipkin
```shell
docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.opentelemetry.zipkin.yml up
```

Go to http://localhost:9411 to view trace data with the Zipkin UI.

#### OTLP
```shell
docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.opentelemetry.otlp.yml up
```

The OTLP collector is configured via the `otel-collector-config.yaml` file. It is configured to receive OTLP data and export it via the logging exporter which logs data out to the console.

#### Console
```shell
docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.opentelemetry.console.yml up
```

The console exporter logs data directly out to the console from the app generating the telemetry data.

### Next steps

I think it would be great to demonstrate instrumenting all eShopOnContainer services with OpenTelemetry - including the non-.NET ones. I figure starting with a couple services could be a good start for laying the groundwork for organizing the integration of OpenTelemetry.

There's much more that can be demonstrated. Some eShopOnContainers services use things like gRPC, RabbitMQ, SQL Server, etc. - all of these provide opportunities to show how to instrument them with OpenTelemetry. Each instrumentation module also supports a variety of different configuration options that could be showcased.

Let me know what you think. If there's appetite for this effort, I'd love to collaborate with folks on this.

@cijothomas