### PR TITLE
Updated xmlhttprequest-ssl package to 1.6.2

### DIFF
--- a/src/Web/WebSPA/package-lock.json
+++ b/src/Web/WebSPA/package-lock.json
@@ -14273,7 +14273,7 @@
             "parseqs": "0.0.6",
             "parseuri": "0.0.6",
             "ws": "~7.4.2",
-            "xmlhttprequest-ssl": "~1.5.4",
+            "xmlhttprequest-ssl": "^1.6.2",
             "yeast": "0.1.2"
           },
           "dependencies": {
@@ -17086,9 +17086,9 @@
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz",
+      "integrity": "sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==",
       "dev": true
     },
     "xregexp": {


### PR DESCRIPTION
This PR updates the package `xmlhttprequest-ssl` to `1.6.2`