### PR TITLE
Updated npm package in webspa

### DIFF
--- a/src/Web/WebSPA/package-lock.json
+++ b/src/Web/WebSPA/package-lock.json
@@ -9729,15 +9729,15 @@
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
-        "normalize-url": "1.9.1",
+        "normalize-url": "4.5.1",
         "schema-utils": "^1.0.0",
         "webpack-sources": "^1.1.0"
       },
-      "dependencies": {
+      "dependencies": {        
         "normalize-url": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-          "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+          "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
           "dev": true,
           "requires": {
             "object-assign": "^4.0.1",
@@ -10116,9 +10116,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "normalize.css": {
@@ -11561,7 +11561,7 @@
       "dev": true,
       "requires": {
         "is-absolute-url": "^2.0.0",
-        "normalize-url": "^3.0.0",
+        "normalize-url": "^4.5.1",
         "postcss": "^8.2.10",
         "postcss-value-parser": "^3.0.0"
       },


### PR DESCRIPTION
This PR updates the `normalize-url` package to version `4.5.1`