### PR TITLE
Local K8s change DNS to host.docker.internal

### DIFF
--- a/deploy/k8s/helm/deploy-all.ps1
+++ b/deploy/k8s/helm/deploy-all.ps1
@@ -61,7 +61,7 @@ $ingressValuesFile="ingress_values.yaml"
 
 if ($useLocalk8s -eq $true) {
     $ingressValuesFile="ingress_values_dockerk8s.yaml"
-    $dns="localhost"
+    $dns="host.docker.internal"
 }
 
 if ($externalDns -eq "aks") {

--- a/deploy/k8s/helm/deploy-all.sh
+++ b/deploy/k8s/helm/deploy-all.sh
@@ -160,7 +160,7 @@ ingress_values_file="ingress_values.yaml"
 
 if [[ $use_local_k8s ]]; then
   ingress_values_file="ingress_values_dockerk8s.yaml"
-  dns="host.minikube.internal"
+  dns="host.docker.internal"
 fi
 
 if [[ $dns == "aks" ]]; then


### PR DESCRIPTION
Changing the dns entry in the script for local deployments from 'localhost' to 'host.docker.internal' allows for a clean local install without the need for the section "Known Behaviors" at [https://github.com/dotnet-architecture/eShopOnContainers/wiki/Deploy-to-Local-Kubernetes#Known-Behaviours](https://github.com/dotnet-architecture/eShopOnContainers/wiki/Deploy-to-Local-Kubernetes#Known-Behaviours).

Not only is it cleaner and faster but also less error prone. The instructions in said section did not work for me as the SQL Server container presented errors after restarting it (failure to login as 'sa').

Note that 'host.docker.internal' is specific to Docker Desktop but this should be ok as the document is specific to that environment. 