### PR TITLE
Binding queue using existing cosumerChannel

### DIFF
--- a/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.cs
+++ b/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.cs
@@ -143,13 +143,10 @@ namespace Microsoft.eShopOnContainers.BuildingBlocks.EventBusRabbitMQ
                 {
                     _persistentConnection.TryConnect();
                 }
-
-                using (var channel = _persistentConnection.CreateModel())
-                {
-                    channel.QueueBind(queue: _queueName,
-                                      exchange: BROKER_NAME,
-                                      routingKey: eventName);
-                }
+ 
+                _consumerChannel.QueueBind(queue: _queueName,
+                                    exchange: BROKER_NAME,
+                                    routingKey: eventName);
             }
         }
 


### PR DESCRIPTION
Fix #1701 
Binding queue using existing `_cosumerChannel` rather than create a new channel every time.
I've tested by shutting down the RabbitMQ container then restart again, the bindings are still connected.