### PR TITLE
Seeking feedback: Build and run on .Net 6 preview 6

### DIFF
--- a/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile
+++ b/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile
+++ b/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile
+++ b/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile.develop
+++ b/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile.develop
+++ b/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Mobile.Shopping.HttpAggregator.csproj
+++ b/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Mobile.Shopping.HttpAggregator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Mobile.Shopping.HttpAggregator</AssemblyName>
     <RootNamespace>Microsoft.eShopOnContainers.Mobile.Shopping.HttpAggregator</RootNamespace>
     <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>

--- a/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile
+++ b/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile
+++ b/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile
+++ b/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile.develop
+++ b/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile.develop
+++ b/src/ApiGateways/Web.Bff.Shopping/aggregator/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/ApiGateways/Web.Bff.Shopping/aggregator/Web.Shopping.HttpAggregator.csproj
+++ b/src/ApiGateways/Web.Bff.Shopping/aggregator/Web.Shopping.HttpAggregator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Web.Shopping.HttpAggregator</AssemblyName>
     <RootNamespace>Microsoft.eShopOnContainers.Web.Shopping.HttpAggregator</RootNamespace>
     <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>

--- a/src/BuildingBlocks/Devspaces.Support/Devspaces.Support.csproj
+++ b/src/BuildingBlocks/Devspaces.Support/Devspaces.Support.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />

--- a/src/BuildingBlocks/EventBus/EventBus.Tests/EventBus.Tests.csproj
+++ b/src/BuildingBlocks/EventBus/EventBus.Tests/EventBus.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BuildingBlocks/EventBus/EventBus/EventBus.csproj
+++ b/src/BuildingBlocks/EventBus/EventBus/EventBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBus</RootNamespace>
   </PropertyGroup>
 

--- a/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.csproj
+++ b/src/BuildingBlocks/EventBus/EventBusRabbitMQ/EventBusRabbitMQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBusRabbitMQ</RootNamespace>
   </PropertyGroup>
 

--- a/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.csproj
+++ b/src/BuildingBlocks/EventBus/EventBusServiceBus/EventBusServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.EventBusServiceBus</RootNamespace>
   </PropertyGroup>
 

--- a/src/BuildingBlocks/EventBus/IntegrationEventLogEF/IntegrationEventLogEF.csproj
+++ b/src/BuildingBlocks/EventBus/IntegrationEventLogEF/IntegrationEventLogEF.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.eShopOnContainers.BuildingBlocks.IntegrationEventLogEF</RootNamespace>
   </PropertyGroup>
 

--- a/src/BuildingBlocks/WebHostCustomization/WebHost.Customization/WebHost.Customization.csproj
+++ b/src/BuildingBlocks/WebHostCustomization/WebHost.Customization/WebHost.Customization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
   </PropertyGroup>
 

--- a/src/Services/Basket/Basket.API/Basket.API.csproj
+++ b/src/Services/Basket/Basket.API/Basket.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
     <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>

--- a/src/Services/Basket/Basket.API/Dockerfile
+++ b/src/Services/Basket/Basket.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Basket/Basket.API/Dockerfile
+++ b/src/Services/Basket/Basket.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Basket/Basket.API/Dockerfile
+++ b/src/Services/Basket/Basket.API/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Basket/Basket.API/Dockerfile.develop
+++ b/src/Services/Basket/Basket.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Basket/Basket.API/Dockerfile.develop
+++ b/src/Services/Basket/Basket.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Basket/Basket.API/Program.cs
+++ b/src/Services/Basket/Basket.API/Program.cs
@@ -64,7 +64,7 @@ IWebHost BuildWebHost(IConfiguration configuration, string[] args) =>
         .UseSerilog()
         .Build();
 
-ILogger CreateSerilogLogger(IConfiguration configuration)
+Serilog.ILogger CreateSerilogLogger(IConfiguration configuration)
 {
     var seqServerUrl = configuration["Serilog:SeqServerUrl"];
     var logstashUrl = configuration["Serilog:LogstashgUrl"];

--- a/src/Services/Basket/Basket.FunctionalTests/Basket.FunctionalTests.csproj
+++ b/src/Services/Basket/Basket.FunctionalTests/Basket.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Services/Basket/Basket.UnitTests/Basket.UnitTests.csproj
+++ b/src/Services/Basket/Basket.UnitTests/Basket.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Services/Catalog/Catalog.API/Catalog.API.csproj
+++ b/src/Services/Catalog/Catalog.API/Catalog.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DebugType>portable</DebugType>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Catalog.API</AssemblyName>

--- a/src/Services/Catalog/Catalog.API/Dockerfile
+++ b/src/Services/Catalog/Catalog.API/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Catalog/Catalog.API/Dockerfile
+++ b/src/Services/Catalog/Catalog.API/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Catalog/Catalog.API/Dockerfile
+++ b/src/Services/Catalog/Catalog.API/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Catalog/Catalog.API/Dockerfile.develop
+++ b/src/Services/Catalog/Catalog.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Catalog/Catalog.API/Dockerfile.develop
+++ b/src/Services/Catalog/Catalog.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Catalog/Catalog.FunctionalTests/Catalog.FunctionalTests.csproj
+++ b/src/Services/Catalog/Catalog.FunctionalTests/Catalog.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Services/Catalog/Catalog.UnitTests/Catalog.UnitTests.csproj
+++ b/src/Services/Catalog/Catalog.UnitTests/Catalog.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Services/Identity/Identity.API/Dockerfile
+++ b/src/Services/Identity/Identity.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Identity/Identity.API/Dockerfile
+++ b/src/Services/Identity/Identity.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Identity/Identity.API/Dockerfile
+++ b/src/Services/Identity/Identity.API/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Identity/Identity.API/Dockerfile.develop
+++ b/src/Services/Identity/Identity.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Identity/Identity.API/Dockerfile.develop
+++ b/src/Services/Identity/Identity.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Identity/Identity.API/Identity.API.csproj
+++ b/src/Services/Identity/Identity.API/Identity.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>aspnet-eShopOnContainers.Identity-90487118-103c-4ff0-b9da-e5e26f7ab0c5</UserSecretsId>
     <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>

--- a/src/Services/Ordering/Ordering.API/Dockerfile
+++ b/src/Services/Ordering/Ordering.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Ordering/Ordering.API/Dockerfile
+++ b/src/Services/Ordering/Ordering.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Ordering/Ordering.API/Dockerfile
+++ b/src/Services/Ordering/Ordering.API/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Ordering/Ordering.API/Dockerfile.develop
+++ b/src/Services/Ordering/Ordering.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Ordering/Ordering.API/Dockerfile.develop
+++ b/src/Services/Ordering/Ordering.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Ordering/Ordering.API/Ordering.API.csproj
+++ b/src/Services/Ordering/Ordering.API/Ordering.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>aspnet-Ordering.API-20161122013547</UserSecretsId>
     <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
     <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>

--- a/src/Services/Ordering/Ordering.BackgroundTasks/Dockerfile
+++ b/src/Services/Ordering/Ordering.BackgroundTasks/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Ordering/Ordering.BackgroundTasks/Dockerfile
+++ b/src/Services/Ordering/Ordering.BackgroundTasks/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Ordering/Ordering.BackgroundTasks/Dockerfile
+++ b/src/Services/Ordering/Ordering.BackgroundTasks/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Ordering/Ordering.BackgroundTasks/Ordering.BackgroundTasks.csproj
+++ b/src/Services/Ordering/Ordering.BackgroundTasks/Ordering.BackgroundTasks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>dotnet-Ordering.BackgroundTasks-9D3E1DD6-405B-447F-8AAB-1708B36D260E</UserSecretsId>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/src/Services/Ordering/Ordering.Domain/Ordering.Domain.csproj
+++ b/src/Services/Ordering/Ordering.Domain/Ordering.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Services/Ordering/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
+++ b/src/Services/Ordering/Ordering.FunctionalTests/Ordering.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Services/Ordering/Ordering.Infrastructure/Ordering.Infrastructure.csproj
+++ b/src/Services/Ordering/Ordering.Infrastructure/Ordering.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Services/Ordering/Ordering.SignalrHub/Dockerfile
+++ b/src/Services/Ordering/Ordering.SignalrHub/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Ordering/Ordering.SignalrHub/Dockerfile
+++ b/src/Services/Ordering/Ordering.SignalrHub/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Ordering/Ordering.SignalrHub/Dockerfile
+++ b/src/Services/Ordering/Ordering.SignalrHub/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Ordering/Ordering.SignalrHub/Dockerfile.develop
+++ b/src/Services/Ordering/Ordering.SignalrHub/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Ordering/Ordering.SignalrHub/Dockerfile.develop
+++ b/src/Services/Ordering/Ordering.SignalrHub/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Ordering/Ordering.SignalrHub/Ordering.SignalrHub.csproj
+++ b/src/Services/Ordering/Ordering.SignalrHub/Ordering.SignalrHub.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>

--- a/src/Services/Ordering/Ordering.UnitTests/Ordering.UnitTests.csproj
+++ b/src/Services/Ordering/Ordering.UnitTests/Ordering.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Services/Payment/Payment.API/Dockerfile
+++ b/src/Services/Payment/Payment.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Payment/Payment.API/Dockerfile
+++ b/src/Services/Payment/Payment.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Payment/Payment.API/Dockerfile
+++ b/src/Services/Payment/Payment.API/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Payment/Payment.API/Dockerfile.develop
+++ b/src/Services/Payment/Payment.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Payment/Payment.API/Dockerfile.develop
+++ b/src/Services/Payment/Payment.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Payment/Payment.API/Payment.API.csproj
+++ b/src/Services/Payment/Payment.API/Payment.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DockerComposeProjectPath>..\..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
     <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>

--- a/src/Services/Webhooks/Webhooks.API/Dockerfile
+++ b/src/Services/Webhooks/Webhooks.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Webhooks/Webhooks.API/Dockerfile
+++ b/src/Services/Webhooks/Webhooks.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Webhooks/Webhooks.API/Dockerfile
+++ b/src/Services/Webhooks/Webhooks.API/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Services/Webhooks/Webhooks.API/Dockerfile.develop
+++ b/src/Services/Webhooks/Webhooks.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Webhooks/Webhooks.API/Dockerfile.develop
+++ b/src/Services/Webhooks/Webhooks.API/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Services/Webhooks/Webhooks.API/Webhooks.API.csproj
+++ b/src/Services/Webhooks/Webhooks.API/Webhooks.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>

--- a/src/Tests/Services/Application.FunctionalTests/Application.FunctionalTests.csproj
+++ b/src/Tests/Services/Application.FunctionalTests/Application.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/Web/WebMVC/Dockerfile
+++ b/src/Web/WebMVC/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Web/WebMVC/Dockerfile
+++ b/src/Web/WebMVC/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Web/WebMVC/Dockerfile
+++ b/src/Web/WebMVC/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Web/WebMVC/Dockerfile.develop
+++ b/src/Web/WebMVC/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Web/WebMVC/Dockerfile.develop
+++ b/src/Web/WebMVC/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/src/Web/WebMVC/Infrastructure/WebContextSeed.cs
+++ b/src/Web/WebMVC/Infrastructure/WebContextSeed.cs
@@ -32,7 +32,7 @@ namespace WebMVC.Infrastructure
             }
         }
 
-        static void GetPreconfiguredCSS(string contentRootPath, string webroot, ILogger log)
+        static void GetPreconfiguredCSS(string contentRootPath, string webroot, Serilog.ILogger log)
         {
             try
             {
@@ -52,7 +52,7 @@ namespace WebMVC.Infrastructure
             }
         }
 
-        static void GetPreconfiguredImages(string contentRootPath, string webroot, ILogger log)
+        static void GetPreconfiguredImages(string contentRootPath, string webroot, Serilog.ILogger log)
         {
             try
             {

--- a/src/Web/WebMVC/WebMVC.csproj
+++ b/src/Web/WebMVC/WebMVC.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>aspnet-Microsoft.eShopOnContainers-946ae052-8305-4a99-965b-ec8636ddbae3</UserSecretsId>
     <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
     <TypeScriptToolsVersion>3.0</TypeScriptToolsVersion>

--- a/src/Web/WebSPA/Dockerfile
+++ b/src/Web/WebSPA/Dockerfile
@@ -1,7 +1,7 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 ARG NODE_IMAGE=node:12.0
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
@@ -14,7 +14,7 @@ RUN npm install
 COPY Web/WebSPA/Client .
 RUN npm run build:prod
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # Create this "restore-solution" section by running ./Create-DockerfileSolutionRestore.ps1, to optimize build cache reuse

--- a/src/Web/WebSPA/Dockerfile
+++ b/src/Web/WebSPA/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install
 COPY Web/WebSPA/Client .
 RUN npm run build:prod
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # Create this "restore-solution" section by running ./Create-DockerfileSolutionRestore.ps1, to optimize build cache reuse

--- a/src/Web/WebSPA/Dockerfile
+++ b/src/Web/WebSPA/Dockerfile
@@ -1,7 +1,7 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 ARG NODE_IMAGE=node:12.0
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
@@ -14,7 +14,7 @@ RUN npm install
 COPY Web/WebSPA/Client .
 RUN npm run build:prod
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # Create this "restore-solution" section by running ./Create-DockerfileSolutionRestore.ps1, to optimize build cache reuse

--- a/src/Web/WebSPA/WebSPA.csproj
+++ b/src/Web/WebSPA/WebSPA.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>aspnetcorespa-c23d27a4-eb88-4b18-9b77-2a93f3b15119</UserSecretsId>
     <TypeScriptCompileOnSaveEnabled>false</TypeScriptCompileOnSaveEnabled>
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>

--- a/src/Web/WebStatus/Dockerfile
+++ b/src/Web/WebStatus/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Web/WebStatus/Dockerfile
+++ b/src/Web/WebStatus/Dockerfile
@@ -44,10 +44,10 @@ COPY "docker-compose.dcproj" "docker-compose.dcproj"
 
 COPY "NuGet.config" "NuGet.config"
 
-RUN dotnet restore "eShopOnContainers-ServicesAndWebApps.sln"
+# RUN dotnet restore "eShopOnContainers-ServicesAndWebApps.sln"
 COPY . .
 WORKDIR /src/Web/WebStatus
-RUN dotnet publish --no-restore -c Release -o /app
+RUN dotnet publish -c Release -o /app
 
 FROM build AS publish
 

--- a/src/Web/WebStatus/Dockerfile
+++ b/src/Web/WebStatus/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Web/WebStatus/Dockerfile
+++ b/src/Web/WebStatus/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Web/WebStatus/Dockerfile
+++ b/src/Web/WebStatus/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Web/WebStatus/WebStatus.csproj
+++ b/src/Web/WebStatus/WebStatus.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
     <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>

--- a/src/Web/WebStatus/WebStatus.csproj
+++ b/src/Web/WebStatus/WebStatus.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
     <DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>

--- a/src/Web/WebhookClient/Dockerfile
+++ b/src/Web/WebhookClient/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Web/WebhookClient/Dockerfile
+++ b/src/Web/WebhookClient/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Web/WebhookClient/Dockerfile
+++ b/src/Web/WebhookClient/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-preview.6 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.0-preview.6 AS build
 WORKDIR /src
 
 # It's important to keep lines from here down to "COPY . ." identical in all Dockerfiles

--- a/src/Web/WebhookClient/WebhookClient.csproj
+++ b/src/Web/WebhookClient/WebhookClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <UserSecretsId>36215d41-f31a-4aa6-9929-bd67d650e7b5</UserSecretsId>


### PR DESCRIPTION
It's probably premature to merge this, but I am seeking feedback on my attempt to upgrade eShopOnContainers to .NET 6 preview 6. 

I work for New Relic and we are using eShopOnContainers as a validation tool for our compatibility with .NET 6.

I was able to get everything working via docker-compose on CLI on windows. The only thing I wasn't able to upgrade to .Net 6 was the WebStatus app which experiences a strange issue with a Linq .Any() command throwing an error about multiple results being returned when upgraded to .Net 6??? I was getting similar issues in other services and upgrading the NuGet references for EF seemed to solve it, but not for the WebStatus project.

I'm interested in collaborating on upgrading this project to .NET 6. I upgraded ALL the NuGet packages at first and found some huge issues with the changes to the IdentityServer API. I'm sure there are other challenging tasks like this where you want to upgrade to the latest and greatest versions across this whole stack.

