### PR TITLE
Update ValidateOrAddBuyerAggregateWhenOrderStartedDomainEventHandler.cs

### DIFF
--- a/src/Services/Ordering/Ordering.API/Application/DomainEventHandlers/OrderStartedEvent/ValidateOrAddBuyerAggregateWhenOrderStartedDomainEventHandler.cs
+++ b/src/Services/Ordering/Ordering.API/Application/DomainEventHandlers/OrderStartedEvent/ValidateOrAddBuyerAggregateWhenOrderStartedDomainEventHandler.cs
@@ -54,8 +54,8 @@ namespace Ordering.API.Application.DomainEventHandlers.OrderStartedEvent
                 _buyerRepository.Update(buyer) :
                 _buyerRepository.Add(buyer);
 
-            await _buyerRepository.UnitOfWork
-                .SaveEntitiesAsync(cancellationToken);
+            //await _buyerRepository.UnitOfWork
+            //    .SaveEntitiesAsync(cancellationToken);
 
             var orderStatusChangedTosubmittedIntegrationEvent = new OrderStatusChangedToSubmittedIntegrationEvent(orderStartedEvent.Order.Id, orderStartedEvent.Order.OrderStatus.Name, buyer.Name);
             await _orderingIntegrationEventService.AddAndSaveEventAsync(orderStatusChangedTosubmittedIntegrationEvent);


### PR DESCRIPTION
Call this method in field events is redundant? It shouldn't exist