### PR TITLE
fix constructor injection for _validators

### DIFF
--- a/src/Services/Ordering/Ordering.API/Application/Behaviors/ValidatorBehavior.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Behaviors/ValidatorBehavior.cs
@@ -3,9 +3,9 @@
 public class ValidatorBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
 {
     private readonly ILogger<ValidatorBehavior<TRequest, TResponse>> _logger;
-    private readonly IValidator<TRequest>[] _validators;
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
 
-    public ValidatorBehavior(IValidator<TRequest>[] validators, ILogger<ValidatorBehavior<TRequest, TResponse>> logger)
+    public ValidatorBehavior(IEnumerable<IValidator<TRequest>> validators, ILogger<ValidatorBehavior<TRequest, TResponse>> logger)
     {
         _validators = validators;
         _logger = logger;


### PR DESCRIPTION
Array can't be used for constructor injection in ValidatorBehavior class and it makes a runtime error.
IEnumerable is the right type for fixing this issue.