### PR TITLE
Update jsonpointer version 5.0.0, ansi-html version to 0.0.8 and webp…

### DIFF
--- a/src/Web/WebSPA/Client/package-lock.json
+++ b/src/Web/WebSPA/Client/package-lock.json
@@ -1386,10 +1386,10 @@
         "webpack-dev-server": {
           "version": "3.11.3",
           "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
-          "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
+          "integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
           "dev": true,
           "requires": {
-            "ansi-html-community": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+            "ansi-html-community": "0.0.8",
             "bonjour": "^3.5.0",
             "chokidar": "^2.1.8",
             "compression": "^1.7.4",
@@ -4373,8 +4373,8 @@
     },
     "ansi-html-community": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+      "resolved": "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw=="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -18412,7 +18412,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
       "integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
       "requires": {
-        "ansi-html-community": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+        "ansi-html-community": "0.0.8",
         "bonjour": "^3.5.0",
         "chokidar": "^2.0.0",
         "compression": "^1.5.2",

--- a/src/Web/WebSPA/Client/package-lock.json
+++ b/src/Web/WebSPA/Client/package-lock.json
@@ -105,7 +105,7 @@
         "tree-kill": "1.2.2",
         "webpack": "4.44.2",
         "webpack-dev-middleware": "3.7.2",
-        "webpack-dev-server": "3.11.2",
+        "webpack-dev-server": "3.11.3",
         "webpack-merge": "5.7.3",
         "webpack-sources": "2.2.0",
         "webpack-subresource-integrity": "1.5.2",
@@ -1384,12 +1384,12 @@
           }
         },
         "webpack-dev-server": {
-          "version": "3.11.2",
-          "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz",
+          "version": "3.11.3",
+          "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
           "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
           "dev": true,
           "requires": {
-            "ansi-html": "0.0.7",
+            "ansi-html-community": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
             "bonjour": "^3.5.0",
             "chokidar": "^2.1.8",
             "compression": "^1.7.4",
@@ -4371,9 +4371,9 @@
         "type-fest": "^0.21.3"
       }
     },
-    "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+    "ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
@@ -10009,7 +10009,7 @@
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
         "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
+        "jsonpointer": "^5.0.0",
         "xtend": "^4.0.0"
       }
     },
@@ -18412,7 +18412,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
       "integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
       "requires": {
-        "ansi-html": "0.0.7",
+        "ansi-html-community": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
         "bonjour": "^3.5.0",
         "chokidar": "^2.0.0",
         "compression": "^1.5.2",

--- a/src/Web/WebSPA/Client/package.json
+++ b/src/Web/WebSPA/Client/package.json
@@ -57,7 +57,7 @@
     "ssri": ">=8.0.1",
     "tslib": "^2.0.0",
     "typedoc": "^0.19.2",
-    "webpack-dev-server": "3.1.14",
+    "webpack-dev-server": "3.11.3",
     "zone.js": "~0.10.2"
   },
   "devDependencies": {

--- a/src/Web/WebSPA/Client/yarn.lock
+++ b/src/Web/WebSPA/Client/yarn.lock
@@ -1746,6 +1746,11 @@ ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz"
 
+ansi-html-community@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
+  integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
@@ -9449,6 +9454,7 @@ webpack-dev-server@3.1.14:
 webpack-dev-server@3.11.3:
   version "3.11.3"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz#8c86b9d2812bf135d3c9bce6f07b718e30f7c3d3"
+  integrity sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==
   dependencies:
     ansi-html-community "0.0.8"
     bonjour "^3.5.0"

--- a/src/Web/WebSPA/Client/yarn.lock
+++ b/src/Web/WebSPA/Client/yarn.lock
@@ -81,7 +81,7 @@
     tree-kill "1.2.2"
     webpack "4.44.2"
     webpack-dev-middleware "3.7.2"
-    webpack-dev-server "3.11.2"
+    webpack-dev-server "3.11.3"
     webpack-merge "5.7.3"
     webpack-sources "2.2.0"
     webpack-subresource-integrity "1.5.2"
@@ -9415,7 +9415,7 @@ webpack-dev-server@3.1.14:
   version "3.1.14"
   resolved "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz"
   dependencies:
-    ansi-html "0.0.7"
+    ansi-html-community "0.0.8"
     bonjour "^3.5.0"
     chokidar "^2.0.0"
     compression "^1.5.2"
@@ -9446,11 +9446,11 @@ webpack-dev-server@3.1.14:
     webpack-log "^2.0.0"
     yargs "12.0.2"
 
-webpack-dev-server@3.11.2:
-  version "3.11.2"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz#695ebced76a4929f0d5de7fd73fafe185fe33708"
+webpack-dev-server@3.11.3:
+  version "3.11.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz#8c86b9d2812bf135d3c9bce6f07b718e30f7c3d3"
   dependencies:
-    ansi-html "0.0.7"
+    ansi-html-community "0.0.8"
     bonjour "^3.5.0"
     chokidar "^2.1.8"
     compression "^1.7.4"


### PR DESCRIPTION
To resolve dependabot alerts updated jsonpointer version to 5.0.0, ansi-html version to 0.0.8 and webpack-dev-server  to webpack-dev-server version 3.11.2 was using ansi-html which is depreciated but in latest version 3.11.3 it's changed to ansi-html-community version 0.0.8.

