### PR TITLE
Identity Server Startup.cs comment spelling mistake

### DIFF
--- a/src/Services/Identity/Identity.API/Startup.cs
+++ b/src/Services/Identity/Identity.API/Startup.cs
@@ -133,7 +133,7 @@ namespace Microsoft.eShopOnContainers.Services.Identity.API
             app.UseIdentityServer();
 
             // Fix a problem with chrome. Chrome enabled a new feature "Cookies without SameSite must be secure", 
-            // the coockies shold be expided from https, but in eShop, the internal comunicacion in aks and docker compose is http.
+            // the coockies shold be expided from https, but in eShop, the internal communication in aks and docker compose is http.
             // To avoid this problem, the policy of cookies shold be in Lax mode.
             app.UseCookiePolicy(new CookiePolicyOptions { MinimumSameSitePolicy = AspNetCore.Http.SameSiteMode.Lax });
             app.UseRouting();

--- a/src/Services/Identity/Identity.API/Startup.cs
+++ b/src/Services/Identity/Identity.API/Startup.cs
@@ -133,8 +133,8 @@ namespace Microsoft.eShopOnContainers.Services.Identity.API
             app.UseIdentityServer();
 
             // Fix a problem with chrome. Chrome enabled a new feature "Cookies without SameSite must be secure", 
-            // the coockies shold be expided from https, but in eShop, the internal communication in aks and docker compose is http.
-            // To avoid this problem, the policy of cookies shold be in Lax mode.
+            // the cookies should be expired from https, but in eShop, the internal communication in aks and docker compose is http.
+            // To avoid this problem, the policy of cookies should be in Lax mode.
             app.UseCookiePolicy(new CookiePolicyOptions { MinimumSameSitePolicy = AspNetCore.Http.SameSiteMode.Lax });
             app.UseRouting();
                         


### PR DESCRIPTION
In Identity.API project of eShopContainer project, there is a spelling mistake in comment of app.UseCookiePolicy() function of  Startup.cs file. I edited this spelling mistake from "comunicacion" to "communication".