### PR TITLE
Short usage added to IUnitOfWork get methods.

### DIFF
--- a/src/Services/Ordering/Ordering.Infrastructure/Repositories/BuyerRepository.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/Repositories/BuyerRepository.cs
@@ -4,13 +4,7 @@ public class BuyerRepository
     : IBuyerRepository
 {
     private readonly OrderingContext _context;
-    public IUnitOfWork UnitOfWork
-    {
-        get
-        {
-            return _context;
-        }
-    }
+    public IUnitOfWork UnitOfWork => _context;
 
     public BuyerRepository(OrderingContext context)
     {

--- a/src/Services/Ordering/Ordering.Infrastructure/Repositories/OrderRepository.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/Repositories/OrderRepository.cs
@@ -5,13 +5,7 @@ public class OrderRepository
 {
     private readonly OrderingContext _context;
 
-    public IUnitOfWork UnitOfWork
-    {
-        get
-        {
-            return _context;
-        }
-    }
+    public IUnitOfWork UnitOfWork => _context;
 
     public OrderRepository(OrderingContext context)
     {


### PR DESCRIPTION
`=>` used in get methods for more clean code.