### PR TITLE
MediatR error solved.

### DIFF
--- a/src/Services/Ordering/Ordering.API/Application/Behaviors/LoggingBehavior.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Behaviors/LoggingBehavior.cs
@@ -1,5 +1,5 @@
 ﻿namespace Microsoft.eShopOnContainers.Services.Ordering.API.Application.Behaviors;
-public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
 {
     private readonly ILogger<LoggingBehavior<TRequest, TResponse>> _logger;
     public LoggingBehavior(ILogger<LoggingBehavior<TRequest, TResponse>> logger) => _logger = logger;

--- a/src/Services/Ordering/Ordering.API/Application/Behaviors/TransactionBehaviour.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Behaviors/TransactionBehaviour.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.Extensions.Logging;
 
-public class TransactionBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+public class TransactionBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
 {
     private readonly ILogger<TransactionBehaviour<TRequest, TResponse>> _logger;
     private readonly OrderingContext _dbContext;

--- a/src/Services/Ordering/Ordering.API/Application/Behaviors/ValidatorBehavior.cs
+++ b/src/Services/Ordering/Ordering.API/Application/Behaviors/ValidatorBehavior.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.eShopOnContainers.Services.Ordering.API.Application.Behaviors;
 
-public class ValidatorBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+public class ValidatorBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
 {
     private readonly ILogger<ValidatorBehavior<TRequest, TResponse>> _logger;
     private readonly IEnumerable<IValidator<TRequest>> _validators;

--- a/src/Services/Ordering/Ordering.API/GlobalUsings.cs
+++ b/src/Services/Ordering/Ordering.API/GlobalUsings.cs
@@ -83,3 +83,4 @@ global using System.Runtime.Serialization;
 global using System.Threading.Tasks;
 global using System.Threading;
 global using System;
+global using System.Collections.Generic;

--- a/src/Services/Ordering/Ordering.API/Ordering.API.csproj
+++ b/src/Services/Ordering/Ordering.API/Ordering.API.csproj
@@ -48,8 +48,8 @@
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
     <PackageReference Include="Grpc.AspNetCore.Server" Version="2.34.0" />
     <PackageReference Include="Grpc.Tools" Version="2.34.0" PrivateAssets="All" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.18.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.18.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.Kubernetes" Version="2.0.1" />

--- a/src/Services/Ordering/Ordering.Domain/Ordering.Domain.csproj
+++ b/src/Services/Ordering/Ordering.Domain/Ordering.Domain.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/Services/Ordering/Ordering.Infrastructure/GlobalUsings.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/GlobalUsings.cs
@@ -15,3 +15,4 @@ global using System.Linq;
 global using System.Threading.Tasks;
 global using System.Threading;
 global using System;
+global using System.Collections.Generic;

--- a/src/Services/Ordering/Ordering.Infrastructure/Ordering.Infrastructure.csproj
+++ b/src/Services/Ordering/Ordering.Infrastructure/Ordering.Infrastructure.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="9.0.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />

--- a/src/Services/Ordering/Ordering.Infrastructure/OrderingContext.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/OrderingContext.cs
@@ -118,6 +118,16 @@ public class OrderingContextDesignFactory : IDesignTimeDbContextFactory<Ordering
 
     class NoMediator : IMediator
     {
+        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
+        {
+            return default(IAsyncEnumerable<TResponse>);
+        }
+
+        public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
+        {
+            return default(IAsyncEnumerable<object?>);
+        }
+
         public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default(CancellationToken)) where TNotification : INotification
         {
             return Task.CompletedTask;

--- a/src/Services/Ordering/Ordering.UnitTests/Ordering.UnitTests.csproj
+++ b/src/Services/Ordering/Ordering.UnitTests/Ordering.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.0" />
     <PackageReference Include="Moq" Version="4.15.2" />


### PR DESCRIPTION
I accidentally closed the topic #1892. This pull request continuation of topic #1892. After reviewing error, i figure out error is about version incompatibility of MediatR. I currently use MediatR 10.0.1 and MediatR.Extensions.Microsoft.DependencyInjection 10.0.1 in my project. After downgrade my MediatR version from 10.0.1 to 9.0.0 (currently used in dotnet-architecture/eShopOnContainers), error was solved. So, if eShopOnContainers will use MediatR 10.0.1, where `TRequest : IRequest <TResponse>` code snippet have to added all of behavior classes inside of src/Services/Ordering/Ordering.API/Application/Behaviors/ path. 
