### PR TITLE
adding TrustServerCertificate=true to ConnectionString in Helm templates

### DIFF
--- a/deploy/k8s/helm/catalog-api/templates/configmap.yaml
+++ b/deploy/k8s/helm/catalog-api/templates/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  catalog__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.catalog.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};
+  catalog__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.catalog.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};TrustServerCertificate={{ .Values.inf.sql.common.TrustServerCertificate }};
   catalog__PicBaseUrl: {{ $protocol }}://{{ $webshoppingapigw }}/c/api/v1/catalog/items/[0]/pic/
   catalog__AzureStorageEnabled: "{{ .Values.inf.misc.useAzureStorage }}"
   all__EventBusConnection: {{ .Values.inf.eventbus.constr }}

--- a/deploy/k8s/helm/identity-api/templates/configmap.yaml
+++ b/deploy/k8s/helm/identity-api/templates/configmap.yaml
@@ -20,7 +20,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  identity__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.identity.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};
+  identity__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.identity.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};TrustServerCertificate={{ .Values.inf.sql.common.TrustServerCertificate }};
   identity__keystore: {{ .Values.inf.redis.keystore.constr }}
   all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
   mvc_e: http://{{ $mvc_url }}

--- a/deploy/k8s/helm/inf.yaml
+++ b/deploy/k8s/helm/inf.yaml
@@ -13,6 +13,7 @@ inf:
       user: sa              # SQL user
       pwd: Pass@word        # SQL pwd
       pid: Developer
+      TrustServerCertificate: true
     catalog:                # inf.sql.catalog: settings for the catalog-api sql (user, pwd, db)
       db: CatalogDb         # Catalog API SQL db name
     ordering:               # inf.sql.ordering: settings for the ordering-api sql (user, pwd, db)

--- a/deploy/k8s/helm/ordering-api/templates/configmap.yaml
+++ b/deploy/k8s/helm/ordering-api/templates/configmap.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  ordering__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.ordering.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};
+  ordering__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.ordering.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};TrustServerCertificate={{ .Values.inf.sql.common.TrustServerCertificate }};
   urls__IdentityUrl: http://{{ .Values.app.svc.identity }}
   all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
   all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"

--- a/deploy/k8s/helm/ordering-backgroundtasks/templates/configmap.yaml
+++ b/deploy/k8s/helm/ordering-backgroundtasks/templates/configmap.yaml
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  ordering__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.ordering.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};
+  ordering__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.ordering.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};TrustServerCertificate={{ .Values.inf.sql.common.TrustServerCertificate }};
   ordering__EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"
   all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
   all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"

--- a/deploy/k8s/helm/webhooks-api/templates/configmap.yaml
+++ b/deploy/k8s/helm/webhooks-api/templates/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  webhooks__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.webhooks.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};
+  webhooks__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.webhooks.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};TrustServerCertificate={{ .Values.inf.sql.common.TrustServerCertificate }};
   urls__IdentityUrl: http://{{ $identity }}
   urls__IdentityUrlExternal: {{ $protocol }}://{{ $identity }}
   all__EventBusConnection: {{ .Values.inf.eventbus.constr }}


### PR DESCRIPTION
Looks like the default connection string that's baked into images in #2048 is overriden when deploying with helm charts. Adding the `TrustServerCertificate` to configMaps in `deploy/k8s/helm`.