### PR TITLE
Refactor redundant null check and use null-conditional operator

### DIFF
--- a/src/Services/Identity/Identity.API/Quickstart/Consent/ConsentController.cs
+++ b/src/Services/Identity/Identity.API/Quickstart/Consent/ConsentController.cs
@@ -84,7 +84,7 @@ public class ConsentController : Controller
         var result = new ProcessConsentResult();
 
         // validate return url is still valid
-        var request = await _interaction.GetAuthorizationContextAsync(model.ReturnUrl);
+        var request = await _interaction.GetAuthorizationContextAsync(model?.ReturnUrl);
         if (request == null) return result;
 
         ConsentResponse grantedConsent = null;

--- a/src/Web/WebMVC/Infrastructure/API.cs
+++ b/src/Web/WebMVC/Infrastructure/API.cs
@@ -61,7 +61,7 @@ public static class API
             }
             else if (brand.HasValue)
             {
-                var brandQs = (brand.HasValue) ? brand.Value.ToString() : string.Empty;
+                var brandQs = brand.Value.ToString();
                 filterQs = $"/type/all/brand/{brandQs}";
             }
             else


### PR DESCRIPTION
This pull request refactors two sections of the code to improve readability and robustness.

The first change updates the null check in the assignment of the filterQs variable to remove redundancy. The brand.HasValue check was used twice, which is not necessary. The null check was removed from the variable assignment and placed only in the if statement where it is needed.

The second change updates the call to GetAuthorizationContextAsync to use the null-conditional operator ?.. This helps to avoid a potential NullReferenceException if the model object is null.