### PR TITLE
Upgrade GitHub's Checkout action to version 3

### DIFF
--- a/.github/workflows/basket-api-deploy.yml
+++ b/.github/workflows/basket-api-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/basket-api.yml
+++ b/.github/workflows/basket-api.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/catalog-api-deploy.yml
+++ b/.github/workflows/catalog-api-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/catalog-api.yml
+++ b/.github/workflows/catalog-api.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-test
       with:
         service: ${{ env.SERVICE }}
@@ -47,7 +47,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/identity-api-deploy.yml
+++ b/.github/workflows/identity-api-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/identity-api.yml
+++ b/.github/workflows/identity-api.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/mobileshoppingagg-deploy.yml
+++ b/.github/workflows/mobileshoppingagg-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/mobileshoppingagg.yml
+++ b/.github/workflows/mobileshoppingagg.yml
@@ -28,7 +28,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -39,7 +39,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/ordering-api-deploy.yml
+++ b/.github/workflows/ordering-api-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/ordering-api.yml
+++ b/.github/workflows/ordering-api.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-test
       with:
         service: ${{ env.SERVICE }}
@@ -47,7 +47,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/ordering-backgroundtasks-deploy.yml
+++ b/.github/workflows/ordering-backgroundtasks-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/ordering-backgroundtasks.yml
+++ b/.github/workflows/ordering-backgroundtasks.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/ordering-signalrhub-deploy.yml
+++ b/.github/workflows/ordering-signalrhub-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/ordering-signalrhub.yml
+++ b/.github/workflows/ordering-signalrhub.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/payment-api-deploy.yml
+++ b/.github/workflows/payment-api-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/payment-api.yml
+++ b/.github/workflows/payment-api.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/webhooks-api-deploy.yml
+++ b/.github/workflows/webhooks-api-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/webhooks-api.yml
+++ b/.github/workflows/webhooks-api.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/webhooks-client.yml
+++ b/.github/workflows/webhooks-client.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/webmvc-deploy.yml
+++ b/.github/workflows/webmvc-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: azure/login@v1
         with:

--- a/.github/workflows/webmvc.yml
+++ b/.github/workflows/webmvc.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -42,7 +42,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/webshoppingagg-deploy.yml
+++ b/.github/workflows/webshoppingagg-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/webshoppingagg.yml
+++ b/.github/workflows/webshoppingagg.yml
@@ -28,7 +28,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -39,7 +39,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/webspa-deploy.yml
+++ b/.github/workflows/webspa-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/webspa.yml
+++ b/.github/workflows/webspa.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}

--- a/.github/workflows/webstatus-deploy.yml
+++ b/.github/workflows/webstatus-deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/composite/deploy-helm
         with:

--- a/.github/workflows/webstatus.yml
+++ b/.github/workflows/webstatus.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build
       with:
         service: ${{ env.SERVICE }}
@@ -42,7 +42,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - uses: ./.github/workflows/composite/build-push
       with:
         service: ${{ env.SERVICE }}


### PR DESCRIPTION
The recommended version of GitHub's Checkout action is 3 right now.
This also fixes the warnings on the actions :

> **Warning**
> 
>Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.