### PR TITLE
Cache JsonSerializerOptions

### DIFF
--- a/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Services/OrderApiClient.cs
+++ b/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Services/OrderApiClient.cs
@@ -23,9 +23,6 @@ public class OrderApiClient : IOrderApiClient
 
         var ordersDraftResponse = await response.Content.ReadAsStringAsync();
 
-        return JsonSerializer.Deserialize<OrderData>(ordersDraftResponse, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        return JsonSerializer.Deserialize<OrderData>(ordersDraftResponse, JsonHelper.CaseInsensitiveOptions);
     }
 }

--- a/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Services/OrderApiClient.cs
+++ b/src/ApiGateways/Mobile.Bff.Shopping/aggregator/Services/OrderApiClient.cs
@@ -23,6 +23,6 @@ public class OrderApiClient : IOrderApiClient
 
         var ordersDraftResponse = await response.Content.ReadAsStringAsync();
 
-        return JsonSerializer.Deserialize<OrderData>(ordersDraftResponse, JsonHelper.CaseInsensitiveOptions);
+        return JsonSerializer.Deserialize<OrderData>(ordersDraftResponse, JsonDefaults.CaseInsensitiveOptions);
     }
 }

--- a/src/ApiGateways/Web.Bff.Shopping/aggregator/Services/OrderApiClient.cs
+++ b/src/ApiGateways/Web.Bff.Shopping/aggregator/Services/OrderApiClient.cs
@@ -23,9 +23,6 @@ public class OrderApiClient : IOrderApiClient
 
         var ordersDraftResponse = await response.Content.ReadAsStringAsync();
 
-        return JsonSerializer.Deserialize<OrderData>(ordersDraftResponse, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        return JsonSerializer.Deserialize<OrderData>(ordersDraftResponse, JsonHelper.CaseInsensitiveOptions);
     }
 }

--- a/src/ApiGateways/Web.Bff.Shopping/aggregator/Services/OrderApiClient.cs
+++ b/src/ApiGateways/Web.Bff.Shopping/aggregator/Services/OrderApiClient.cs
@@ -23,6 +23,6 @@ public class OrderApiClient : IOrderApiClient
 
         var ordersDraftResponse = await response.Content.ReadAsStringAsync();
 
-        return JsonSerializer.Deserialize<OrderData>(ordersDraftResponse, JsonHelper.CaseInsensitiveOptions);
+        return JsonSerializer.Deserialize<OrderData>(ordersDraftResponse, JsonDefaults.CaseInsensitiveOptions);
     }
 }

--- a/src/BuildingBlocks/EventBus/IntegrationEventLogEF/IntegrationEventLogEntry.cs
+++ b/src/BuildingBlocks/EventBus/IntegrationEventLogEF/IntegrationEventLogEntry.cs
@@ -2,16 +2,16 @@
 
 public class IntegrationEventLogEntry
 {
+    private static readonly JsonSerializerOptions s_indentedOptions = new() { WriteIndented = true };
+    private static readonly JsonSerializerOptions s_caseInsensitiveOptions = new() { PropertyNameCaseInsensitive = true };
+
     private IntegrationEventLogEntry() { }
     public IntegrationEventLogEntry(IntegrationEvent @event, Guid transactionId)
     {
         EventId = @event.Id;
         CreationTime = @event.CreationDate;
         EventTypeName = @event.GetType().FullName;
-        Content = JsonSerializer.Serialize(@event, @event.GetType(), new JsonSerializerOptions
-        {
-            WriteIndented = true
-        });
+        Content = JsonSerializer.Serialize(@event, @event.GetType(), s_indentedOptions);
         State = EventStateEnum.NotPublished;
         TimesSent = 0;
         TransactionId = transactionId.ToString();
@@ -30,7 +30,7 @@ public class IntegrationEventLogEntry
 
     public IntegrationEventLogEntry DeserializeJsonContent(Type type)
     {
-        IntegrationEvent = JsonSerializer.Deserialize(Content, type, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true }) as IntegrationEvent;
+        IntegrationEvent = JsonSerializer.Deserialize(Content, type, s_caseInsensitiveOptions) as IntegrationEvent;
         return this;
     }
 }

--- a/src/Services/Basket/Basket.API/Repositories/RedisBasketRepository.cs
+++ b/src/Services/Basket/Basket.API/Repositories/RedisBasketRepository.cs
@@ -35,15 +35,12 @@ public class RedisBasketRepository : IBasketRepository
             return null;
         }
 
-        return JsonSerializer.Deserialize<CustomerBasket>(data, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        return JsonSerializer.Deserialize<CustomerBasket>(data, JsonHelper.CaseInsensitiveOptions);
     }
 
     public async Task<CustomerBasket> UpdateBasketAsync(CustomerBasket basket)
     {
-        var created = await _database.StringSetAsync(basket.BuyerId, JsonSerializer.Serialize(basket));
+        var created = await _database.StringSetAsync(basket.BuyerId, JsonSerializer.Serialize(basket, JsonHelper.CaseInsensitiveOptions));
 
         if (!created)
         {
@@ -51,7 +48,7 @@ public class RedisBasketRepository : IBasketRepository
             return null;
         }
 
-        _logger.LogInformation("Basket item persisted succesfully.");
+        _logger.LogInformation("Basket item persisted successfully.");
 
         return await GetBasketAsync(basket.BuyerId);
     }

--- a/src/Services/Basket/Basket.API/Repositories/RedisBasketRepository.cs
+++ b/src/Services/Basket/Basket.API/Repositories/RedisBasketRepository.cs
@@ -35,12 +35,12 @@ public class RedisBasketRepository : IBasketRepository
             return null;
         }
 
-        return JsonSerializer.Deserialize<CustomerBasket>(data, JsonHelper.CaseInsensitiveOptions);
+        return JsonSerializer.Deserialize<CustomerBasket>(data, JsonDefaults.CaseInsensitiveOptions);
     }
 
     public async Task<CustomerBasket> UpdateBasketAsync(CustomerBasket basket)
     {
-        var created = await _database.StringSetAsync(basket.BuyerId, JsonSerializer.Serialize(basket, JsonHelper.CaseInsensitiveOptions));
+        var created = await _database.StringSetAsync(basket.BuyerId, JsonSerializer.Serialize(basket, JsonDefaults.CaseInsensitiveOptions));
 
         if (!created)
         {

--- a/src/Services/Services.Common/JsonDefaults.cs
+++ b/src/Services/Services.Common/JsonDefaults.cs
@@ -2,7 +2,7 @@
 
 namespace Services.Common;
 
-public static class JsonHelper
+public static class JsonDefaults
 {
     public static readonly JsonSerializerOptions CaseInsensitiveOptions = new()
     {

--- a/src/Services/Services.Common/JsonHelper.cs
+++ b/src/Services/Services.Common/JsonHelper.cs
@@ -1,12 +1,11 @@
 ﻿using System.Text.Json;
 
-namespace Services.Common
+namespace Services.Common;
+
+public static class JsonHelper
 {
-    public static class JsonHelper
+    public static readonly JsonSerializerOptions CaseInsensitiveOptions = new()
     {
-        public static readonly JsonSerializerOptions CaseInsensitiveOptions = new()
-        {
-            PropertyNameCaseInsensitive = true
-        };
-    }
+        PropertyNameCaseInsensitive = true
+    };
 }

--- a/src/Services/Services.Common/JsonHelper.cs
+++ b/src/Services/Services.Common/JsonHelper.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json;
+
+namespace Services.Common
+{
+    public static class JsonHelper
+    {
+        public static readonly JsonSerializerOptions CaseInsensitiveOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+    }
+}

--- a/src/Web/WebMVC/Services/BasketService.cs
+++ b/src/Web/WebMVC/Services/BasketService.cs
@@ -29,7 +29,7 @@ public class BasketService : IBasketService
         var responseString = await response.Content.ReadAsStringAsync();
         return string.IsNullOrEmpty(responseString) ?
             new Basket() { BuyerId = user.Id } :
-            JsonSerializer.Deserialize<Basket>(responseString, JsonHelper.CaseInsensitiveOptions);
+            JsonSerializer.Deserialize<Basket>(responseString, JsonDefaults.CaseInsensitiveOptions);
     }
 
     public async Task<Basket> UpdateBasket(Basket basket)
@@ -79,7 +79,7 @@ public class BasketService : IBasketService
 
         var jsonResponse = await response.Content.ReadAsStringAsync();
 
-        return JsonSerializer.Deserialize<Basket>(jsonResponse, JsonHelper.CaseInsensitiveOptions);
+        return JsonSerializer.Deserialize<Basket>(jsonResponse, JsonDefaults.CaseInsensitiveOptions);
     }
 
     public async Task<Order> GetOrderDraft(string basketId)
@@ -88,7 +88,7 @@ public class BasketService : IBasketService
 
         var responseString = await _apiClient.GetStringAsync(uri);
 
-        var response = JsonSerializer.Deserialize<Order>(responseString, JsonHelper.CaseInsensitiveOptions);
+        var response = JsonSerializer.Deserialize<Order>(responseString, JsonDefaults.CaseInsensitiveOptions);
 
         return response;
     }

--- a/src/Web/WebMVC/Services/BasketService.cs
+++ b/src/Web/WebMVC/Services/BasketService.cs
@@ -29,10 +29,7 @@ public class BasketService : IBasketService
         var responseString = await response.Content.ReadAsStringAsync();
         return string.IsNullOrEmpty(responseString) ?
             new Basket() { BuyerId = user.Id } :
-            JsonSerializer.Deserialize<Basket>(responseString, new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            });
+            JsonSerializer.Deserialize<Basket>(responseString, JsonHelper.CaseInsensitiveOptions);
     }
 
     public async Task<Basket> UpdateBasket(Basket basket)
@@ -82,10 +79,7 @@ public class BasketService : IBasketService
 
         var jsonResponse = await response.Content.ReadAsStringAsync();
 
-        return JsonSerializer.Deserialize<Basket>(jsonResponse, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        return JsonSerializer.Deserialize<Basket>(jsonResponse, JsonHelper.CaseInsensitiveOptions);
     }
 
     public async Task<Order> GetOrderDraft(string basketId)
@@ -94,10 +88,7 @@ public class BasketService : IBasketService
 
         var responseString = await _apiClient.GetStringAsync(uri);
 
-        var response = JsonSerializer.Deserialize<Order>(responseString, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        var response = JsonSerializer.Deserialize<Order>(responseString, JsonHelper.CaseInsensitiveOptions);
 
         return response;
     }

--- a/src/Web/WebMVC/Services/CatalogService.cs
+++ b/src/Web/WebMVC/Services/CatalogService.cs
@@ -23,7 +23,7 @@ public class CatalogService : ICatalogService
 
         var responseString = await _httpClient.GetStringAsync(uri);
 
-        var catalog = JsonSerializer.Deserialize<Catalog>(responseString, JsonHelper.CaseInsensitiveOptions);
+        var catalog = JsonSerializer.Deserialize<Catalog>(responseString, JsonDefaults.CaseInsensitiveOptions);
 
         return catalog;
     }

--- a/src/Web/WebMVC/Services/CatalogService.cs
+++ b/src/Web/WebMVC/Services/CatalogService.cs
@@ -23,10 +23,7 @@ public class CatalogService : ICatalogService
 
         var responseString = await _httpClient.GetStringAsync(uri);
 
-        var catalog = JsonSerializer.Deserialize<Catalog>(responseString, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        var catalog = JsonSerializer.Deserialize<Catalog>(responseString, JsonHelper.CaseInsensitiveOptions);
 
         return catalog;
     }

--- a/src/Web/WebMVC/Services/OrderingService.cs
+++ b/src/Web/WebMVC/Services/OrderingService.cs
@@ -23,10 +23,7 @@ public class OrderingService : IOrderingService
 
         var responseString = await _httpClient.GetStringAsync(uri);
 
-        var response = JsonSerializer.Deserialize<Order>(responseString, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        var response = JsonSerializer.Deserialize<Order>(responseString, JsonHelper.CaseInsensitiveOptions);
 
         return response;
     }
@@ -37,10 +34,7 @@ public class OrderingService : IOrderingService
 
         var responseString = await _httpClient.GetStringAsync(uri);
 
-        var response = JsonSerializer.Deserialize<List<Order>>(responseString, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        var response = JsonSerializer.Deserialize<List<Order>>(responseString, JsonHelper.CaseInsensitiveOptions);
 
         return response;
     }

--- a/src/Web/WebMVC/Services/OrderingService.cs
+++ b/src/Web/WebMVC/Services/OrderingService.cs
@@ -23,7 +23,7 @@ public class OrderingService : IOrderingService
 
         var responseString = await _httpClient.GetStringAsync(uri);
 
-        var response = JsonSerializer.Deserialize<Order>(responseString, JsonHelper.CaseInsensitiveOptions);
+        var response = JsonSerializer.Deserialize<Order>(responseString, JsonDefaults.CaseInsensitiveOptions);
 
         return response;
     }
@@ -34,7 +34,7 @@ public class OrderingService : IOrderingService
 
         var responseString = await _httpClient.GetStringAsync(uri);
 
-        var response = JsonSerializer.Deserialize<List<Order>>(responseString, JsonHelper.CaseInsensitiveOptions);
+        var response = JsonSerializer.Deserialize<List<Order>>(responseString, JsonDefaults.CaseInsensitiveOptions);
 
         return response;
     }

--- a/src/Web/WebhookClient/Services/WebhooksClient.cs
+++ b/src/Web/WebhookClient/Services/WebhooksClient.cs
@@ -14,7 +14,7 @@ public class WebhooksClient : IWebhooksClient
         var client = _httpClientFactory.CreateClient("GrantClient");
         var response = await client.GetAsync(_options.WebhooksUrl + "/api/v1/webhooks");
         var json = await response.Content.ReadAsStringAsync();
-        var subscriptions = JsonSerializer.Deserialize<IEnumerable<WebhookResponse>>(json, JsonHelper.CaseInsensitiveOptions);
+        var subscriptions = JsonSerializer.Deserialize<IEnumerable<WebhookResponse>>(json, JsonDefaults.CaseInsensitiveOptions);
         return subscriptions;
     }
 }

--- a/src/Web/WebhookClient/Services/WebhooksClient.cs
+++ b/src/Web/WebhookClient/Services/WebhooksClient.cs
@@ -14,10 +14,7 @@ public class WebhooksClient : IWebhooksClient
         var client = _httpClientFactory.CreateClient("GrantClient");
         var response = await client.GetAsync(_options.WebhooksUrl + "/api/v1/webhooks");
         var json = await response.Content.ReadAsStringAsync();
-        var subscriptions = JsonSerializer.Deserialize<IEnumerable<WebhookResponse>>(json, new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+        var subscriptions = JsonSerializer.Deserialize<IEnumerable<WebhookResponse>>(json, JsonHelper.CaseInsensitiveOptions);
         return subscriptions;
     }
 }


### PR DESCRIPTION
According to https://github.com/dotnet/runtime/issues/65396, using a new JsonSerializerOptions every time JsonSerializer is invoked is a suboptimal pattern.

Fix this by caching JsonSerializerOptions instances.

cc @davidfowl @ReubenBond @eiriktsarpalis